### PR TITLE
[ISSUE #144] Fix nil pointer when file not exist

### DIFF
--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -45,10 +45,8 @@ func MakeFileIfNotExist(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if err = os.MkdirAll(path, 0755); err != nil {
-				return err
-			}
-			return nil
+			err = os.MkdirAll(path, 0755)
+			return err
 		}
 	}
 	if !info.IsDir() {

--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -48,6 +48,7 @@ func MakeFileIfNotExist(path string) error {
 			if err = os.MkdirAll(path, 0755); err != nil {
 				return err
 			}
+			return nil
 		}
 	}
 	if !info.IsDir() {


### PR DESCRIPTION
```go
func MakeFileIfNotExist(path string) error {
       //when path is not exist,  info: nil   err:  error | *os.PathError
	info, err := os.Stat(path) 
	if err != nil {
		if os.IsNotExist(err) {
			if err = os.MkdirAll(path, 0755); err != nil {
				return err
			}
		}
	}
        // info still nil after mkdir
	if !info.IsDir() {
		return errors.New(path + " is a file")
	}
	return nil
}
```