### PR TITLE
[ISSUE #183]  add set consumeMessageBatchMaxSize and fixed count++ skip one message…

### DIFF
--- a/consumer/option.go
+++ b/consumer/option.go
@@ -147,6 +147,12 @@ func WithConsumerOrder(order bool) Option {
 	}
 }
 
+func WithConsumeMessageBatchMaxSize(consumeMessageBatchMaxSize int) Option {
+	return func(options *consumerOptions) {
+		options.ConsumeMessageBatchMaxSize = consumeMessageBatchMaxSize
+	}
+}
+
 // WithChainConsumerInterceptor returns a ConsumerOption that specifies the chained interceptor for consumer.
 // The first interceptor will be the outer most, while the last interceptor will be the inner most wrapper
 // around the real call.

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -699,7 +699,7 @@ func (pc *pushConsumer) consumeMessageCurrently(pq *processQueue, mq *primitive.
 		} else {
 			next := count + pc.option.ConsumeMessageBatchMaxSize
 			subMsgs = msgs[count:next]
-			count = next
+			count = next - 1
 		}
 		go func() {
 		RETRY:


### PR DESCRIPTION
… bug

## What is the purpose of the change

In consumer/push_consumer.go  func (pc *pushConsumer) consumeMessageCurrently
```go
for count := 0; count < len(msgs); count++ {
        var subMsgs []*primitive.MessageExt
        if count+pc.option.ConsumeMessageBatchMaxSize > len(msgs) {
            subMsgs = msgs[count:]
            count = len(msgs)
        } else {
            next := count + pc.option.ConsumeMessageBatchMaxSize
            subMsgs = msgs[count:next]
            count = next
        }
        //other codes
```
In count+pc.option.ConsumeMessageBatchMaxSize is less than len(msgs) branch, the param count wii be set param next value, but there is count++ in for statement, then it will skip one message. so I change
```go
count = next
```
to
```go
count = next - 1
```

## Brief changelog

add WithConsumeMessageBatchMaxSize function


## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [√] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [√] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [√] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [√] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
