### PR TITLE
[ISSUE #201]Change default consumer option to Clustering

### DIFF
--- a/consumer/option.go
+++ b/consumer/option.go
@@ -113,6 +113,7 @@ func defaultPushConsumerOptions() consumerOptions {
 		MaxTimeConsumeContinuously: time.Duration(60 * time.Second),
 		RebalanceLockInterval:      20 * time.Second,
 		MaxReconsumeTimes:          -1,
+		ConsumerModel:              Clustering,
 		AutoCommit:                 true,
 	}
 	opts.ClientOptions.GroupName = "DEFAULT_CONSUMER"

--- a/consumer/push_consumer_test.go
+++ b/consumer/push_consumer_test.go
@@ -36,6 +36,7 @@ func TestStart(t *testing.T) {
 		c, _ := NewPushConsumer(
 			WithGroupName("testGroup"),
 			WithNameServer([]string{"127.0.0.1:9876"}),
+			WithConsumerModel(BroadCasting),
 		)
 
 		ctrl := gomock.NewController(t)


### PR DESCRIPTION
## What is the purpose of the change

[ISSUE #201 ]Change default consumer option to Clustering in consumer option

## Brief changelog

Change default consumer option to Clustering in consumer option

## Verifying this change

Change default consumer option to Clustering in consumer option

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
