### PR TITLE
[ISSUE #211]fix unmarhsal messageID bug

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -13,7 +13,6 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/leyafo/rocketmq-client-go v0.0.0-20190915102151-ba3a8e36af7e h1:DRdGjp1WwYiDBIbTTO1GhtsLKX0o+VxaH/KY0HJi3Tw=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/leyafo/rocketmq-client-go v0.0.0-20190915102151-ba3a8e36af7e h1:DRdGjp1WwYiDBIbTTO1GhtsLKX0o+VxaH/KY0HJi3Tw=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/primitive/message.go
+++ b/primitive/message.go
@@ -392,17 +392,17 @@ func createMessageId(addr []byte, port int32, offset int64) string {
 	return strings.ToUpper(hex.EncodeToString(buffer.Bytes()))
 }
 
-func string2Bytes(hexStr string) []byte {
-	if hexStr == "" {
+func string2Bytes(hexBytes []byte) []byte {
+	if len(hexBytes) == 0 {
 		return nil
 	}
 
-	hexStr = strings.ToUpper(hexStr)
-	length := len(hexStr) / 2
+	hexBytes = bytes.ToUpper(hexBytes)
+	length := len(hexBytes) / 2
 	result := make([]byte, length)
 	for i := 0; i < length; i++ {
 		pos := i * 2
-		result[i] = charToByte(hexStr[pos])<<4 | charToByte(hexStr[pos+1])
+		result[i] = charToByte(hexBytes[pos])<<4 | charToByte(hexBytes[pos+1])
 	}
 	return result
 }

--- a/primitive/message.go
+++ b/primitive/message.go
@@ -411,7 +411,7 @@ func charToByte(c byte) byte {
 	return byte(strings.IndexByte("0123456789ABCDEF", c))
 }
 
-func UnmarshalMsgID(msgID string) (*MessageID, error) {
+func UnmarshalMsgID(msgID []byte) (*MessageID, error) {
 	if len(msgID) < 32 {
 		return nil, fmt.Errorf("%s len < 32", string(msgID))
 	}

--- a/primitive/message_test.go
+++ b/primitive/message_test.go
@@ -20,7 +20,7 @@ package primitive
 import "testing"
 
 func TestMessageID(t *testing.T) {
-	id := "0AAF0895000078BF000000000009BB4A"
+	id := []byte("0AAF0895000078BF000000000009BB4A")
 	msgID, err := UnmarshalMsgID(id)
 	if err != nil {
 		t.Fatalf("unmarshal msg id error, ms is: %s", err.Error())

--- a/primitive/message_test.go
+++ b/primitive/message_test.go
@@ -15,28 +15,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package primitive
 
-import (
-	"bytes"
-	"compress/zlib"
-	"io/ioutil"
-	"net"
-)
+import "testing"
 
-func GetAddressByBytes(data []byte) string {
-	return net.IPv4(data[0], data[1], data[2], data[3]).String()
-}
-
-func UnCompress(data []byte) []byte {
-	rdata := bytes.NewReader(data)
-	r, err := zlib.NewReader(rdata)
+func TestMessageID(t *testing.T) {
+	id := "0AAF0895000078BF000000000009BB4A"
+	msgID, err := UnmarshalMsgID(id)
 	if err != nil {
-		return data
+		t.Fatalf("unmarshal msg id error, ms is: %s", err.Error())
 	}
-	retData, err := ioutil.ReadAll(r)
-	if err != nil {
-		return data
+	if msgID.Addr != "10.175.8.149" {
+		t.Fatalf("parse messageID %s error", id)
 	}
-	return retData
+	if msgID.Port != 30911 {
+		t.Fatalf("parse messageID %s error", id)
+	}
+	if msgID.Offset != 637770 {
+		t.Fatalf("parse messageID %s error", id)
+	}
+	t.Log(msgID)
 }


### PR DESCRIPTION
## What is the purpose of the change
[ISSUE #211] Fix UnmarshalMessageID function. 
Implment GetAddressByBytes function.

## Brief changelog
Convert MessageID to IP:port and offset. The implementation refers to JAVA code.
The IP address which stores in 4byte array, not 8 bytes.

## Verifying this change
The unit-test case from my company online data.
