### PR TITLE
[ISSUE #194]fix: avoid extra err info on pushConsumer startup

### DIFF
--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -114,16 +114,16 @@ func (pc *pushConsumer) Start() error {
 		pc.state = internal.StateStartFailed
 		pc.validate()
 
-		err = pc.defaultConsumer.start()
-		if err != nil {
-			return
-		}
-
 		err := pc.client.RegisterConsumer(pc.consumerGroup, pc)
 		if err != nil {
 			pc.state = internal.StateStartFailed
 			rlog.Errorf("the consumer group: [%s] has been created, specify another name.", pc.consumerGroup)
 			err = ErrCreated
+		}
+
+		err = pc.defaultConsumer.start()
+		if err != nil {
+			return
 		}
 
 		go func() {


### PR DESCRIPTION
- register consumer before defaultConsumer start]

Closes #194