### PR TITLE
[ISSUE #243]fix: replace consistent package

### DIFF
--- a/consumer/strategy.go
+++ b/consumer/strategy.go
@@ -18,11 +18,13 @@ limitations under the License.
 package consumer
 
 import (
+	"strings"
+
+	"stathat.com/c/consistent"
+
 	"github.com/apache/rocketmq-client-go/internal/utils"
 	"github.com/apache/rocketmq-client-go/primitive"
 	"github.com/apache/rocketmq-client-go/rlog"
-	"stathat.com/c/consistent"
-	"strings"
 )
 
 // Strategy Algorithm for message allocating between consumers

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/apache/rocketmq-client-go
 
 require (
-	github.com/agiledragon/gomonkey v0.0.0-20190517145658-8fa491f7b918
 	github.com/emirpasic/gods v1.12.0
 	github.com/golang/mock v1.3.1
 	github.com/pkg/errors v0.8.1
@@ -11,6 +10,8 @@ require (
 	github.com/tidwall/gjson v1.2.1
 	github.com/tidwall/match v1.0.1 // indirect
 	github.com/tidwall/pretty v0.0.0-20190325153808-1166b9ac2b65 // indirect
-	golang.org/x/tools v0.0.0-20190425150028-36563e24a262
 	stathat.com/c/consistent v1.0.0
 )
+
+replace stathat.com/c/consistent v1.0.0 => github.com/stathat/consistent v1.0.0
+

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,3 @@ require (
 )
 
 replace stathat.com/c/consistent v1.0.0 => github.com/stathat/consistent v1.0.0
-

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/agiledragon/gomonkey v0.0.0-20190517145658-8fa491f7b918 h1:a88Ln+jbIokfi6xoKtq10dbgp4VMg1CmHF1J42p8EyE=
-github.com/agiledragon/gomonkey v0.0.0-20190517145658-8fa491f7b918/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -23,6 +21,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945 h1:N8Bg45zpk/UcpNGnfJt2y/3lRWASHNTUET8owPYCgYI=
 github.com/smartystreets/goconvey v0.0.0-20190710185942-9d28bd7c0945/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/stathat/consistent v1.0.0 h1:ZFJ1QTRn8npNBKW065raSZ8xfOqhpb8vLOkfp4CcL/U=
+github.com/stathat/consistent v1.0.0/go.mod h1:uajTPbgSygZBJ+V+0mY7meZ8i0XAcZs7AQ6V121XSxw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION

- replace stathat.com/c/consistent for github.com/stathat/consistent,
  which is free to download

Closes #243
