### PR TITLE
[ISSUE #328] message add GetProperties func

### DIFF
--- a/primitive/message.go
+++ b/primitive/message.go
@@ -133,6 +133,10 @@ func (m *Message) UnmarshalProperties(data []byte) {
 	}
 }
 
+func (m *Message) GetProperties() map[string]string {
+	return m.properties
+}
+
 func NewMessage(topic string, body []byte) *Message {
 	msg := &Message{
 		Topic:      topic,

--- a/primitive/message.go
+++ b/primitive/message.go
@@ -134,7 +134,13 @@ func (m *Message) UnmarshalProperties(data []byte) {
 }
 
 func (m *Message) GetProperties() map[string]string {
-	return m.properties
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	result := make(map[string]string, len(m.properties))
+	for k, v := range m.properties {
+		result[k] = v
+	}
+	return result
 }
 
 func NewMessage(topic string, body []byte) *Message {

--- a/primitive/result_test.go
+++ b/primitive/result_test.go
@@ -49,3 +49,15 @@ func TestCreateMessageId(t *testing.T) {
 	})
 
 }
+
+func TestGetProperties(t *testing.T) {
+	msg1 := NewMessage("test", nil)
+	msg1.properties = map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}
+	assert.Equal(t, msg1.GetProperties(), map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	})
+}


### PR DESCRIPTION
Message struct add GetProperties function
```go
	parentSpanContext, _ := c.tracer.Extract(opentracing.TextMap, opentracing.TextMapCarrier(msg.GetProperties()))
	span := c.tracer.StartSpan(
		fmt.Sprintf("%s@%s", cfg.GroupID, target.Topic),
		ext.SpanKindConsumer,
		tag,
		opentracing.ChildOf(parentSpanContext),
	)
	defer span.Finish()
```