### PR TITLE
[ISSUE #340] change transaction producer interface signature

### DIFF
--- a/examples/producer/transaction/main.go
+++ b/examples/producer/transaction/main.go
@@ -42,7 +42,7 @@ func NewDemoListener() *DemoListener {
 	}
 }
 
-func (dl *DemoListener) ExecuteLocalTransaction(msg primitive.Message) primitive.LocalTransactionState {
+func (dl *DemoListener) ExecuteLocalTransaction(msg *primitive.Message) primitive.LocalTransactionState {
 	nextIndex := atomic.AddInt32(&dl.transactionIndex, 1)
 	fmt.Printf("nextIndex: %v for transactionID: %v\n", nextIndex, msg.TransactionId)
 	status := nextIndex % 3
@@ -52,8 +52,8 @@ func (dl *DemoListener) ExecuteLocalTransaction(msg primitive.Message) primitive
 	return primitive.UnknowState
 }
 
-func (dl *DemoListener) CheckLocalTransaction(msg primitive.MessageExt) primitive.LocalTransactionState {
-	fmt.Printf("msg transactionID : %v\n", msg.TransactionId)
+func (dl *DemoListener) CheckLocalTransaction(msg *primitive.MessageExt) primitive.LocalTransactionState {
+	fmt.Printf("%v msg transactionID : %v\n", time.Now(), msg.TransactionId)
 	v, existed := dl.localTrans.Load(msg.TransactionId)
 	if !existed {
 		fmt.Printf("unknow msg: %v, return Commit", msg)
@@ -74,8 +74,6 @@ func (dl *DemoListener) CheckLocalTransaction(msg primitive.MessageExt) primitiv
 		fmt.Printf("checkLocalTransaction default COMMIT_MESSAGE: %v\n", msg)
 		return primitive.CommitMessageState
 	}
-
-	return primitive.UnknowState
 }
 
 func main() {

--- a/internal/callback.go
+++ b/internal/callback.go
@@ -26,6 +26,6 @@ import (
 // remotingClient callback TransactionProducer
 type CheckTransactionStateCallback struct {
 	Addr   net.Addr
-	Msg    primitive.MessageExt
+	Msg    *primitive.MessageExt
 	Header CheckTransactionStateRequestHeader
 }

--- a/internal/client.go
+++ b/internal/client.go
@@ -212,9 +212,9 @@ func GetOrNewRocketMQClient(option ClientOptions, callbackCh chan interface{}) R
 				rlog.Warning("producer group is not equal", nil)
 				return nil
 			}
-			callback := CheckTransactionStateCallback{
+			callback := &CheckTransactionStateCallback{
 				Addr:   addr,
-				Msg:    *msgExt,
+				Msg:    msgExt,
 				Header: *header,
 			}
 			callbackCh <- callback

--- a/primitive/message.go
+++ b/primitive/message.go
@@ -423,11 +423,11 @@ const (
 
 type TransactionListener interface {
 	//  When send transactional prepare(half) message succeed, this method will be invoked to execute local transaction.
-	ExecuteLocalTransaction(Message) LocalTransactionState
+	ExecuteLocalTransaction(*Message) LocalTransactionState
 
 	// When no response to prepare(half) message. broker will send check message to check the transaction status, and this
 	// method will be invoked to get local transaction status.
-	CheckLocalTransaction(MessageExt) LocalTransactionState
+	CheckLocalTransaction(*MessageExt) LocalTransactionState
 }
 
 type MessageID struct {


### PR DESCRIPTION
1. change TransactionListener  param from struct to struct pointer
2. change CheckLocalTransaction msg member from strucut to pointer, and pass it's pointer to channel order than value
3. add judge before log error in checkTransactionState()

I just use examples/producer/transaction/main.go to test it, and I think should not  hidden bugs after I test and read context code.
#340 
