### PR TITLE
fix: consume type compatible with protocol

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -61,8 +61,8 @@ const (
 type ConsumeType string
 
 const (
-	_PullConsume = ConsumeType("pull")
-	_PushConsume = ConsumeType("push")
+	_PullConsume = ConsumeType("CONSUME_ACTIVELY")
+	_PushConsume = ConsumeType("CONSUME_PASSIVELY")
 
 	_SubAll = "*"
 )


### PR DESCRIPTION
通过 `mqadmin consumerStatus` 查看消费者状态时，命令执行失败。

```
$ NAMESRV_ADDR=localhost:9876 sh bin/mqadmin consumerStatus -g testGroup                                                                                                                                   (rocketmq-all-4.5.2*) 13:37:07
RocketMQLog:WARN No appenders could be found for logger (io.netty.util.internal.PlatformDependent0).
RocketMQLog:WARN Please initialize the logger system properly.
001  172.17.200.98@DEFAULT                    V4_5_2               1578980233054/172.17.200.98@DEFAULT
org.apache.rocketmq.tools.command.SubCommandException: ConsumerStatusSubCommand command failed
        at org.apache.rocketmq.tools.command.consumer.ConsumerStatusSubCommand.execute(ConsumerStatusSubCommand.java:134)
        at org.apache.rocketmq.tools.command.MQAdminStartup.main0(MQAdminStartup.java:139)
        at org.apache.rocketmq.tools.command.MQAdminStartup.main(MQAdminStartup.java:90)
Caused by: java.lang.IllegalArgumentException: No enum constant org.apache.rocketmq.common.protocol.heartbeat.ConsumeType.push
        at java.lang.Enum.valueOf(Enum.java:238)
        at org.apache.rocketmq.common.protocol.heartbeat.ConsumeType.valueOf(ConsumeType.java:23)
        at org.apache.rocketmq.common.protocol.body.ConsumerRunningInfo.analyzeSubscription(ConsumerRunningInfo.java:58)
        at org.apache.rocketmq.tools.command.consumer.ConsumerStatusSubCommand.execute(ConsumerStatusSubCommand.java:105)
        ... 2 more
```

修改 `ConsumeType` 常量值后解决。