### PR TITLE
[ISSUE #407] feat: reuse bytes.Buffer

### DIFF
--- a/primitive/message.go
+++ b/primitive/message.go
@@ -364,7 +364,7 @@ func DecodeMessage(data []byte) []*MessageExt {
 		}
 		count += 2 + int(propertiesLength)
 
-		msg.MsgId = createMessageId(hostBytes, port, msg.CommitLogOffset)
+		msg.MsgId = CreateMessageId(hostBytes, port, msg.CommitLogOffset)
 		//count += 16
 		if msg.properties == nil {
 			msg.properties = make(map[string]string, 0)
@@ -436,11 +436,12 @@ type MessageID struct {
 	Offset int64
 }
 
-func createMessageId(addr []byte, port int32, offset int64) string {
-	buffer := new(bytes.Buffer)
+func CreateMessageId(addr []byte, port int32, offset int64) string {
+	buffer := GetBuffer()
+	defer BackBuffer(buffer)
 	buffer.Write(addr)
-	binary.Write(buffer, binary.BigEndian, port)
-	binary.Write(buffer, binary.BigEndian, offset)
+	_ = binary.Write(buffer, binary.BigEndian, port)
+	_ = binary.Write(buffer, binary.BigEndian, offset)
 	return strings.ToUpper(hex.EncodeToString(buffer.Bytes()))
 }
 

--- a/primitive/pool.go
+++ b/primitive/pool.go
@@ -18,14 +18,19 @@ limitations under the License.
 package primitive
 
 import (
+	"bytes"
 	"sync"
 )
 
 var headerPool = sync.Pool{}
+var bufferPool = sync.Pool{}
 
 func init() {
 	headerPool.New = func() interface{} {
 		return make([]byte, 4)
+	}
+	bufferPool.New = func() interface{} {
+		return new(bytes.Buffer)
 	}
 }
 
@@ -37,4 +42,15 @@ func GetHeader() []byte {
 
 func BackHeader(d []byte) {
 	headerPool.Put(d)
+}
+
+func GetBuffer() *bytes.Buffer {
+	b := bufferPool.Get().(*bytes.Buffer)
+	b.Reset()
+	return b
+}
+
+func BackBuffer(b *bytes.Buffer) {
+	b.Reset()
+	bufferPool.Put(b)
 }

--- a/primitive/result_test.go
+++ b/primitive/result_test.go
@@ -41,9 +41,20 @@ func TestCreateMessageId(t *testing.T) {
 		b := []byte{10, 93, 233, 58}
 		port := int32(10911)
 		offset := int64(4391252)
-		id := createMessageId(b, port, offset)
-
+		id := CreateMessageId(b, port, offset)
 		Convey("generated messageId should be equal to expected", func() {
+			assert.Equal(t, "0A5DE93A00002A9F0000000000430154", id)
+		})
+
+		b2 := []byte("127.0.0.1")
+		port2 := int32(11)
+		offset2 := int64(12)
+		id2 := CreateMessageId(b2, port2, offset2)
+		Convey("new generated messageId should be equal to expected", func() {
+			assert.Equal(t, "3132372E302E302E310000000B000000000000000C", id2)
+		})
+
+		Convey("ex-generated messageId should not change", func() {
 			assert.Equal(t, "0A5DE93A00002A9F0000000000430154", id)
 		})
 	})


### PR DESCRIPTION
- use sync.pool of bytes.Buffer instead of new

Closes #407