### PR TITLE
fix(strategy): change the deafult mq sort to ASC when do rebalance.

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -396,12 +396,12 @@ func (dc *defaultConsumer) doBalance() {
 			sort.SliceStable(mqAll, func(i, j int) bool {
 				v := strings.Compare(mqAll[i].Topic, mqAll[j].Topic)
 				if v != 0 {
-					return v > 0
+					return v < 0
 				}
 
 				v = strings.Compare(mqAll[i].BrokerName, mqAll[j].BrokerName)
 				if v != 0 {
-					return v > 0
+					return v < 0
 				}
 				return (mqAll[i].QueueId - mqAll[j].QueueId) < 0
 			})


### PR DESCRIPTION
close #419 
the message queue list got from the broker should be sort by ASC before do rebalance.
