### PR TITLE
fix(travisci): use archive server to avoid download rocketmq package failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 before_script:
   - cd ${TRAVIS_HOME}
-  - wget http://us.mirrors.quenda.co/apache/rocketmq/4.6.0/rocketmq-all-4.6.0-bin-release.zip
+  - wget https://archive.apache.org/dist/rocketmq/4.6.0/rocketmq-all-4.6.0-bin-release.zip
   - unzip rocketmq-all-4.6.0-bin-release.zip
   - cd rocketmq-all-4.6.0-bin-release
   - perl -i -pe's/-Xms8g -Xmx8g -Xmn4g/-Xms2g -Xmx2g -Xmn1g/g' bin/runbroker.sh


### PR DESCRIPTION
fix(travisci): use archive server to avoid download rocketmq package failed