### PR TITLE
[ISSUE #428] fix(consumer): brokerName not found when broker recover from machine crash.

### DIFF
--- a/internal/route.go
+++ b/internal/route.go
@@ -28,7 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/tidwall/gjson"
 
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
@@ -570,6 +570,10 @@ func (b *BrokerData) Equals(bd *BrokerData) bool {
 	}
 
 	if b.BrokerName != bd.BrokerName {
+		return false
+	}
+
+	if len(b.BrokerAddresses) != len(bd.BrokerAddresses) {
 		return false
 	}
 


### PR DESCRIPTION
motivation:

when broker recover from machine creash, current routeData is not changed due to bug, which should be "change" as expected. then, mq can not be consumed or consuming mq can not update offset.

modification:

- check brokerData.BrokerAddresses len

Closes #428