### PR TITLE
fix(producer): update name server address immediately when client start

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -262,6 +262,7 @@ func (c *rmqClient) Start() {
 		}
 		// fetchNameServerAddr
 		if len(c.option.NameServerAddrs) == 0 {
+			c.namesrvs.UpdateNameServerAddress(c.option.NameServerDomain, c.option.InstanceName)
 			go primitive.WithRecover(func() {
 				op := func() {
 					c.namesrvs.UpdateNameServerAddress(c.option.NameServerDomain, c.option.InstanceName)


### PR DESCRIPTION
Function UpdateNameServerAddress, which is first called after 10s from now, should be called immediately. Or Publish will end up with error.