### PR TITLE
fix(producer): UpdateNameServerAddress shoule be called before producer start, or namesrvs list will be empty, lead to a panic

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -262,6 +262,7 @@ func (c *rmqClient) Start() {
 		}
 		// fetchNameServerAddr
 		if len(c.option.NameServerAddrs) == 0 {
+			c.namesrvs.UpdateNameServerAddress(c.option.NameServerDomain, c.option.InstanceName)
 			go primitive.WithRecover(func() {
 				op := func() {
 					c.namesrvs.UpdateNameServerAddress(c.option.NameServerDomain, c.option.InstanceName)

--- a/internal/client.go
+++ b/internal/client.go
@@ -262,7 +262,6 @@ func (c *rmqClient) Start() {
 		}
 		// fetchNameServerAddr
 		if len(c.option.NameServerAddrs) == 0 {
-			c.namesrvs.UpdateNameServerAddress(c.option.NameServerDomain, c.option.InstanceName)
 			go primitive.WithRecover(func() {
 				op := func() {
 					c.namesrvs.UpdateNameServerAddress(c.option.NameServerDomain, c.option.InstanceName)

--- a/internal/route.go
+++ b/internal/route.go
@@ -344,6 +344,7 @@ func (s *namesrvs) queryTopicRouteInfoFromServer(topic string) (*TopicRouteData,
 	if s.Size() == 0 {
 		rlog.Error("namesrv list empty. UpdateNameServerAddress should be called first.", map[string]interface{}{
 			"namesrv": s,
+			"topic":   topic,
 		})
 		return nil, primitive.NewRemotingErr("namesrv list empty")
 	}
@@ -360,6 +361,7 @@ func (s *namesrvs) queryTopicRouteInfoFromServer(topic string) (*TopicRouteData,
 	if err != nil {
 		rlog.Error("connect to namesrv failed.", map[string]interface{}{
 			"namesrv": s,
+			"topic":   topic,
 		})
 		return nil, primitive.NewRemotingErr(err.Error())
 	}
@@ -375,6 +377,7 @@ func (s *namesrvs) queryTopicRouteInfoFromServer(topic string) (*TopicRouteData,
 		if err != nil {
 			rlog.Warning("decode TopicRouteData error: %s", map[string]interface{}{
 				rlog.LogKeyUnderlayError: err,
+				"topic":                  topic,
 			})
 			return nil, err
 		}

--- a/internal/route.go
+++ b/internal/route.go
@@ -339,6 +339,15 @@ func (s *namesrvs) queryTopicRouteInfoFromServer(topic string) (*TopicRouteData,
 		response *remote.RemotingCommand
 		err      error
 	)
+
+	//if s.Size() == 0, response will be nil, lead to panic below.
+	if s.Size() == 0 {
+		rlog.Error("namesrv list empty. UpdateNameServerAddress should be called first.", map[string]interface{}{
+			"namesrv": s,
+		})
+		return nil, primitive.NewRemotingErr("namesrv list empty")
+	}
+
 	for i := 0; i < s.Size(); i++ {
 		rc := remote.NewRemotingCommand(ReqGetRouteInfoByTopic, request, nil)
 		ctx, _ := context.WithTimeout(context.Background(), requestTimeout)

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -80,7 +80,10 @@ func NewDefaultProducer(opts ...Option) (*defaultProducer, error) {
 
 func (p *defaultProducer) Start() error {
 	atomic.StoreInt32(&p.state, int32(internal.StateRunning))
-	p.options.Namesrv.UpdateNameServerAddress(p.options.NameServerDomain, p.options.InstanceName)
+	if len(p.options.NameServerAddrs) == 0 {
+		p.options.Namesrv.UpdateNameServerAddress(p.options.NameServerDomain, p.options.InstanceName)
+	}
+
 	p.client.RegisterProducer(p.group, p)
 	p.client.Start()
 	return nil

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -80,6 +80,7 @@ func NewDefaultProducer(opts ...Option) (*defaultProducer, error) {
 
 func (p *defaultProducer) Start() error {
 	atomic.StoreInt32(&p.state, int32(internal.StateRunning))
+	p.options.Namesrv.UpdateNameServerAddress(p.options.NameServerDomain, p.options.InstanceName)
 	p.client.RegisterProducer(p.group, p)
 	p.client.Start()
 	return nil


### PR DESCRIPTION
UpdateNameServerAddress shoule be called before producer start, or namesrvs list will be empty, lead to a panic。
Case: in private enviroment, start a consumer first, then start a producer, call publish. There whould be a panic.