### PR TITLE
fix(remotingClient):avoid goroutine leak

### DIFF
--- a/internal/remote/future.go
+++ b/internal/remote/future.go
@@ -62,6 +62,7 @@ func (r *ResponseFuture) waitResponse() (*RemotingCommand, error) {
 	case <-r.Done:
 		cmd, err = r.ResponseCommand, r.Err
 	case <-r.ctx.Done():
+		close(r.Done)
 		err = utils.ErrRequestTimeout
 		r.Err = err
 	}

--- a/internal/remote/remote_client.go
+++ b/internal/remote/remote_client.go
@@ -194,6 +194,14 @@ func (c *remotingClient) processCMD(cmd *RemotingCommand, r *tcpConnWrapper) {
 				responseFuture.ResponseCommand = cmd
 				responseFuture.executeInvokeCallback()
 				if responseFuture.Done != nil {
+					defer func() {
+						if err := recover(); err != nil {
+							rlog.Error("put responseFuture.Done error, maybe caused by timeout: %s", map[string]interface{}{
+								rlog.LogKeyUnderlayError: err,
+							})
+							return
+						}
+					}()
 					responseFuture.Done <- true
 				}
 			})


### PR DESCRIPTION
Change-Id: Ifa0555c45529f84720ef885e5f803f8633e65968

## What is the purpose of the change

fix the goroutine leak for remotingClient.
In the case that ResponseFuture timed out, goroutine would be leak.

## Brief changelog

if  ResponseFuture times out，DONE channel should be closed。


Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
