### PR TITLE
repair memory cache to distinguish between multiple nameservers

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -183,7 +183,7 @@ func GetOrNewRocketMQClient(option ClientOptions, callbackCh chan interface{}) R
 		namesrvs:     option.Namesrv,
 		done:         make(chan struct{}),
 	}
-	actual, loaded := clientMap.LoadOrStore(client.ClientID(), client)
+	actual, loaded := clientMap.LoadOrStore(client.ClientID()+"@"+option.Namesrv.String(), client)
 	if !loaded {
 		client.remoteClient.RegisterRequestFunc(ReqNotifyConsumerIdsChanged, func(req *remote.RemotingCommand, addr net.Addr) *remote.RemotingCommand {
 			rlog.Info("receive broker's notification to consumer group", map[string]interface{}{


### PR DESCRIPTION
## What is the purpose of the change

when multiple nameservers are ensured, the connection obtained by the memory cache is current

## Brief changelog

sync map key to ensure that the same nameserver address is unique

## Verifying this change



Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.
- [x] [ISSUE #521 ]
