### PR TITLE
[ISSUE #530] fix: initialize 0 for retry topic when ConsumeFromLastOffst

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -754,7 +754,7 @@ func (dc *defaultConsumer) computePullFromWhere(mq *primitive.MessageQueue) int6
 		case ConsumeFromLastOffset:
 			if lastOffset == -1 {
 				if strings.HasPrefix(mq.Topic, internal.RetryGroupTopicPrefix) {
-					lastOffset = 0
+					result = 0
 				} else {
 					lastOffset, err := dc.queryMaxOffset(mq)
 					if err == nil {


### PR DESCRIPTION
## What is the purpose of the change

ensure consume correctly from retry topic

## Brief changelog

- initialize offset 0 when start up