### PR TITLE
fix(remote_client):avoid goroutine leak

### DIFF
--- a/internal/remote/remote_client.go
+++ b/internal/remote/remote_client.go
@@ -194,7 +194,7 @@ func (c *remotingClient) processCMD(cmd *RemotingCommand, r *tcpConnWrapper) {
 				responseFuture.ResponseCommand = cmd
 				responseFuture.executeInvokeCallback()
 				if responseFuture.Done != nil {
-					responseFuture.Done <- true
+					close(responseFuture.Done)
 				}
 			})
 		}


### PR DESCRIPTION
Change-Id: Ifa0555c45529f84720ef885e5f803f8633e65968

What is the purpose of the change
fix the goroutine leak for remotingClient.
In the case that ResponseFuture timed out, goroutine would be leak.

Brief changelog
if ResponseFuture times out，DONE channel should be closed。