### PR TITLE
[#540] Fix parse address error when address has prefix "t"

### DIFF
--- a/internal/namesrv.go
+++ b/internal/namesrv.go
@@ -127,7 +127,10 @@ func (s *namesrvs) getNameServerAddress() string {
 	}
 	index %= len(s.srvs)
 	s.index = index
-	return strings.TrimLeft(addr, "http(s)://")
+	if strings.HasPrefix(addr, "https") {
+		return strings.TrimPrefix(addr, "https://")
+	}
+	return strings.TrimPrefix(addr, "http://")
 }
 
 func (s *namesrvs) Size() int {


### PR DESCRIPTION
in same cases, such as addr="http://tim.test.com:9876", then
strings.TrimLeft(addr, "http(s)://") will get "im.test.com:9876" instead
of "tim.test.com:9876"

Signed-off-by: pengfei <julien.zpf@alibaba-inc.com>

## What is the purpose of the change

bugfix

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
