### PR TITLE
FIX:fatal error: concurrent map read and map write(apache#544)

### DIFF
--- a/consumer/mock_offset_store.go
+++ b/consumer/mock_offset_store.go
@@ -22,9 +22,10 @@ limitations under the License.
 package consumer
 
 import (
+	reflect "reflect"
+
 	primitive "github.com/apache/rocketmq-client-go/v2/primitive"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockOffsetStore is a mock of OffsetStore interface

--- a/consumer/offset_store_test.go
+++ b/consumer/offset_store_test.go
@@ -21,12 +21,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
-
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
+	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNewLocalFileOffsetStore(t *testing.T) {
@@ -136,7 +135,7 @@ func TestLocalFileOffsetStore(t *testing.T) {
 			offset = localStore.read(mq, _ReadFromStore)
 			So(offset, ShouldEqual, 1)
 
-			delete(localStore.(*localFileOffsetStore).OffsetTable, MessageQueueKey(*mq))
+			localStore.(*localFileOffsetStore).OffsetTable.Delete(MessageQueueKey(*mq))
 			offset = localStore.read(mq, _ReadMemoryThenStore)
 			So(offset, ShouldEqual, 1)
 		})


### PR DESCRIPTION
## What is the purpose of the change

 avoid `fatal error: concurrent map read and map write`

## Brief changelog

use sync.Map to save` localFileOffsetStore.OffsetTable` info.

## Verifying this change

`go test . -v --run TestNewLocalFileOffsetStore` pass
`go test . -v --run TestLocalFileOffsetStore` pass
