### PR TITLE
[#547] fix bug "it cloud only send one message"

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -381,6 +381,8 @@ func (c *rmqClient) Start() {
 			}
 		})
 	})
+	//set c.close to false, or it could send only one message
+	c.close = false
 }
 
 func (c *rmqClient) Shutdown() {


### PR DESCRIPTION
c.close is set to true after rmq client is shutdown and message could
be sent only if c.close is false, therefore it should be set to false
after starting rmq client.

Signed-off-by: pengfei <julien.zpf@alibaba-inc.com>

## What is the purpose of the change

bugfix

## Brief changelog

set c.close to false after rmq client is started

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
