### PR TITLE
fix: error judgment can't hit export error type

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -18,12 +18,12 @@ limitations under the License.
 package rocketmq
 
 import (
-	"github.com/pkg/errors"
+	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 )
 
 var (
-	ErrRequestTimeout = errors.New("request timeout")
-	ErrMQEmpty        = errors.New("MessageQueue is nil")
-	ErrOffset         = errors.New("offset < 0")
-	ErrNumbers        = errors.New("numbers < 0")
+	ErrRequestTimeout = utils.ErrRequestTimeout
+	ErrMQEmpty        = utils.ErrMQEmpty
+	ErrOffset         = utils.ErrOffset
+	ErrNumbers        = utils.ErrNumbers
 )


### PR DESCRIPTION
## What is the purpose of the change

error judgment can't hit export error type

```go
resp, err := pc.PullFrom(context.Background(), queue, offset, 1)
if err != nil {
	if err == rocketmq.ErrRequestTimeout {
		fmt.Printf("timeout \n")
		time.Sleep(2 * time.Second)
		continue
	}
	fmt.Printf("unexpectable err: %v \n", err)
	return
}
```
`err == rocketmq.ErrRequestTimeout` never work

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
