### PR TITLE
Update nsresolver.go

### DIFF
--- a/primitive/nsresolver.go
+++ b/primitive/nsresolver.go
@@ -130,9 +130,10 @@ func (h *HttpResolver) Description() string {
 
 func (h *HttpResolver) get() []string {
 	resp, err := h.cli.Get(h.domain)
-	if err != nil {
+	if err != nil || resp.StatusCode != 200 {
 		rlog.Error("name server http fetch failed", map[string]interface{}{
 			"NameServerDomain": h.domain,
+			"StatusCode":       resp.StatusCode,
 			"err":              err,
 		})
 		return nil

--- a/primitive/nsresolver.go
+++ b/primitive/nsresolver.go
@@ -130,12 +130,15 @@ func (h *HttpResolver) Description() string {
 
 func (h *HttpResolver) get() []string {
 	resp, err := h.cli.Get(h.domain)
-	if err != nil || resp.StatusCode != 200 {
-		rlog.Error("name server http fetch failed", map[string]interface{}{
+	if err != nil || resp == nil || resp.StatusCode != 200 {
+		data := map[string]interface{}{
 			"NameServerDomain": h.domain,
-			"StatusCode":       resp.StatusCode,
 			"err":              err,
-		})
+		}
+		if resp != nil {
+			data["StatusCode"] = resp.StatusCode
+		}
+		rlog.Error("name server http fetch failed", data)
 		return nil
 	}
 


### PR DESCRIPTION
fix http 5xx srvs error

## What is the purpose of the change

err logs

namesrv="<!DOCTYPE HTML PUBLIC...."

```
time="2020-12-07T19:33:28+08:00" level=error msg="connect to namesrv failed." namesrv="<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\r\n<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body bgcolor=\"white\">\r\n<h1>502 Bad Gateway</h1>\r\n<p>Theproxy server received an invalid response from an upstream server. Sorry for the inconvenience.<br/>\r\nPlease report this message and include the following information to us.<br/>\r\nThank you very much!</p>\r\n<table>\r\n<tr>\r\n<td>URL:</td>\r\n<td>http://jmenv.tbsite.net:8080/rocketmq/nsaddr</td>\r\n</tr>\r\n<tr>\r\n<td>\r\n</tr>\r\n<tr>\r\n<td>Date:</td>\r\n<td>2020/12/07 18:01:28</td>\r\n</tr>\r\n</table>\r\n<hr/>Powered by Tengine</body>\r\n</html>\r\n" topic="%RETRY%your-topic"
```

## Brief changelog

update or set srvs only http 200 ok
