### PR TITLE
fix possible infinite loop after rebalance

### DIFF
--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -465,6 +465,12 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 				return
 			default:
 				pc.submitToConsume(request.pq, request.mq)
+				if request.pq.IsDroppd() {
+					rlog.Info("push consumer quit pullMessage for dropped queue.", map[string]interface{}{
+						rlog.LogKeyConsumerGroup: pc.consumerGroup,
+					})
+					return
+				}
 			}
 		}
 	})


### PR DESCRIPTION
## What is the purpose of the change

fix possible infinite loop after rebalance

## Brief changelog

it's very likely there will be cpu/memory drain caused by dead loop after a rebalance
this fix addressed the issue by check whether the process queue is already dropped before starting next consume


