### PR TITLE
[ISSUE #576] Fix get message property failed after it is set to go msg struct.

### DIFF
--- a/core/message.go
+++ b/core/message.go
@@ -47,6 +47,12 @@ func (msg *Message) String() string {
 
 //GetProperty get message property by key string
 func (msg *Message) GetProperty(key string) string {
+	if msg.Property != nil {
+		v, ok := msg.Property["key"]
+		if ok {
+			return v
+		}
+	}
 	ck := C.CString(key)
 	defer C.free(unsafe.Pointer(ck))
 	return C.GoString(C.GetOriginMessageProperty(msg.cmsg, ck))


### PR DESCRIPTION


## What is the purpose of the change

[ISSUE #576] Fix get message property failed after it is set to go msg struct.
close #576 

## Brief changelog

Get from local msg first before getting from c struct.

## Verifying this change

