### PR TITLE
[ISSUE #568] Update lastPullTime use atomic.Value

### DIFF
--- a/consumer/process_queue.go
+++ b/consumer/process_queue.go
@@ -50,7 +50,7 @@ type processQueue struct {
 	consumeLock                sync.Mutex
 	consumingMsgOrderlyTreeMap *treemap.Map
 	dropped                    *uatomic.Bool
-	lastPullTime               time.Time
+	lastPullTime               atomic.Value
 	lastConsumeTime            atomic.Value
 	locked                     *uatomic.Bool
 	lastLockTime               atomic.Value
@@ -69,9 +69,12 @@ func newProcessQueue(order bool) *processQueue {
 	lastLockTime := atomic.Value{}
 	lastLockTime.Store(time.Now())
 
+	lastPullTime := atomic.Value{}
+	lastPullTime.Store(time.Now())
+
 	pq := &processQueue{
 		msgCache:                   treemap.NewWith(utils.Int64Comparator),
-		lastPullTime:               time.Now(),
+		lastPullTime:               lastPullTime,
 		lastConsumeTime:            lastConsumeTime,
 		lastLockTime:               lastLockTime,
 		msgCh:                      make(chan []*primitive.MessageExt, 32),
@@ -153,6 +156,14 @@ func (pq *processQueue) LastLockTime() time.Time {
 	return pq.lastLockTime.Load().(time.Time)
 }
 
+func (pq *processQueue) LastPullTime() time.Time {
+	return pq.lastPullTime.Load().(time.Time)
+}
+
+func (pq *processQueue) UpdateLastPullTime() {
+	pq.lastPullTime.Store(time.Now())
+}
+
 func (pq *processQueue) makeMessageToCosumeAgain(messages ...*primitive.MessageExt) {
 	pq.mutex.Lock()
 	for _, msg := range messages {
@@ -195,7 +206,7 @@ func (pq *processQueue) isLockExpired() bool {
 }
 
 func (pq *processQueue) isPullExpired() bool {
-	return time.Now().Sub(pq.lastPullTime) > _PullMaxIdleTime
+	return time.Now().Sub(pq.LastPullTime()) > _PullMaxIdleTime
 }
 
 func (pq *processQueue) cleanExpiredMsg(consumer defaultConsumer) {
@@ -356,7 +367,7 @@ func (pq *processQueue) currentInfo() internal.ProcessQueueInfo {
 		TryUnlockTimes:       pq.tryUnlockTimes,
 		LastLockTimestamp:    pq.LastLockTime().UnixNano() / int64(time.Millisecond),
 		Dropped:              pq.dropped.Load(),
-		LastPullTimestamp:    pq.lastPullTime.UnixNano() / int64(time.Millisecond),
+		LastPullTimestamp:    pq.LastPullTime().UnixNano() / int64(time.Millisecond),
 		LastConsumeTimestamp: pq.LastConsumeTime().UnixNano() / int64(time.Millisecond),
 	}
 

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -498,7 +498,7 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 		}
 		// reset time
 		sleepTime = pc.option.PullInterval
-		pq.lastPullTime = time.Now()
+		pq.lastPullTime.Store(time.Now())
 		err := pc.makeSureStateOK()
 		if err != nil {
 			rlog.Warning("consumer state error", map[string]interface{}{


### PR DESCRIPTION
 [ISSUE #568] Update lastPullTime use atomic.Value as same with lastConsumeTime and lastLockTime

## What is the purpose of the change

 [ISSUE #568] Update lastPullTime use atomic.Value as same with lastConsumeTime and lastLockTime

## Brief changelog

 [ISSUE #568] Update lastPullTime use atomic.Value as same with lastConsumeTime and lastLockTime

## Verifying this change

```

func main() {
	var nameSrv string
	var group string
	var topic string
	c, _ := rocketmq.NewPushConsumer(
		consumer.WithNameServer([]string{nameSrv}),
		consumer.WithConsumerModel(consumer.Clustering),
		consumer.WithGroupName(group),
	)
	_ = c.Subscribe(topic, consumer.MessageSelector{}, func(ctx context.Context, msgs ...*primitive.MessageExt) (consumer.ConsumeResult, error) {
		fmt.Printf("subscribe callback: %v \n", msgs)
		return consumer.ConsumeSuccess, nil
	})
	c.Start()
	n := make(chan os.Signal, 1)
	signal.Notify(n, syscall.SIGHUP, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT, syscall.SIGSTOP)
	<-n

}

```

```
go run -race consumer.go
```
