### PR TITLE
[ISSUE #617] retrieve transactionid from property first

### DIFF
--- a/primitive/message.go
+++ b/primitive/message.go
@@ -59,6 +59,7 @@ const (
 	PropertyTranscationCheckTimes          = "TRANSACTION_CHECK_TIMES"
 	PropertyCheckImmunityTimeInSeconds     = "CHECK_IMMUNITY_TIME_IN_SECONDS"
 	PropertyShardingKey                    = "SHARDING_KEY"
+	PropertyTransactionID                  = "__transactionId__"
 )
 
 type Message struct {

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -440,13 +440,20 @@ func (tp *transactionProducer) checkTransactionState() {
 			if uniqueKey == "" {
 				uniqueKey = callback.Msg.MsgId
 			}
+			transactionId := callback.Msg.GetProperty(primitive.PropertyTransactionID)
+			if transactionId == "" {
+				transactionId = callback.Header.TransactionId
+			}
+			if transactionId == "" {
+				transactionId = callback.Msg.TransactionId
+			}
 			header := &internal.EndTransactionRequestHeader{
 				CommitLogOffset:      callback.Header.CommitLogOffset,
 				ProducerGroup:        tp.producer.group,
 				TranStateTableOffset: callback.Header.TranStateTableOffset,
 				FromTransactionCheck: true,
 				MsgID:                uniqueKey,
-				TransactionId:        callback.Header.TransactionId,
+				TransactionId:        transactionId,
 				CommitOrRollback:     tp.transactionState(localTransactionState),
 			}
 


### PR DESCRIPTION
close https://github.com/apache/rocketmq-client-go/issues/617

Signed-off-by: Tenhan Lee <tenhanlee@gmail.com>

## What is the purpose of the change

Solved the memory leak problem with AliyunRocketMQ

## Brief changelog

1. checkTransactionState: retrieve transactionid from property first 
2. add message key: PropertyTransactionID = "__transactionId__" (which AlibabaRocketMQ uses)

## Verifying this change

This change is only for RocketMQ of Alibaba Cloud and will not break the original logic.

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [√] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [√] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [√] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [√] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
