### PR TITLE
[ISSUE #628]takeMessages sleep max 5s

### DIFF
--- a/consumer/process_queue.go
+++ b/consumer/process_queue.go
@@ -274,8 +274,13 @@ func (pq *processQueue) getMessages() []*primitive.MessageExt {
 }
 
 func (pq *processQueue) takeMessages(number int) []*primitive.MessageExt {
+	sleepCount := 0
 	for pq.msgCache.Empty() {
 		time.Sleep(10 * time.Millisecond)
+		if sleepCount > 500 {
+			return nil
+		}
+		sleepCount++
 	}
 	result := make([]*primitive.MessageExt, number)
 	i := 0


### PR DESCRIPTION
fix https://github.com/apache/rocketmq-client-go/issues/628

## What is the purpose of the change

make sure takeMessages can quit when pull request is droped or longtime no message

## Brief changelog

takeMessages sleep max 5s

## Verifying this change

start consumer and make sure no msg for consumer, consumer can quit takeMessage sleep

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
