### PR TITLE
fix: fix crash on selecting queue.

### DIFF
--- a/producer/selector.go
+++ b/producer/selector.go
@@ -44,6 +44,7 @@ func (manualQueueSelector) Select(message *primitive.Message, queues []*primitiv
 
 // randomQueueSelector choose a random queue each time.
 type randomQueueSelector struct {
+	mux    sync.Mutex
 	rander *rand.Rand
 }
 
@@ -53,8 +54,10 @@ func NewRandomQueueSelector() QueueSelector {
 	return s
 }
 
-func (r randomQueueSelector) Select(message *primitive.Message, queues []*primitive.MessageQueue) *primitive.MessageQueue {
+func (r *randomQueueSelector) Select(message *primitive.Message, queues []*primitive.MessageQueue) *primitive.MessageQueue {
+	r.mux.Lock()
 	i := r.rander.Intn(len(queues))
+	r.mux.Unlock()
 	return queues[i]
 }
 


### PR DESCRIPTION
## What is the purpose of the change

fix crash on selecting queue.

## Brief changelog

https://github.com/golang/go/blob/a7e16abb22f1b249d2691b32a5d20206282898f2/src/math/rand/rand.go#L7-L20

The default Source is safe for concurrent use by multiple goroutines, but Sources created by NewSource are not.
如上所述，math/rand中通过NewSource创建的rand方法不是线程安全的。多协程发送消息时，不加锁的情况下同时select queue会因数组越界导致panic。

panic如下：
panic： runtime error: index out of range [-1]
