### PR TITLE
[ISSUE #646] fix responseTable memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![GitHub release](https://img.shields.io/badge/release-download-default.svg)](https://github.com/apache/rocketmq-client-go/releases)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/apache/rocketmq-client-go.svg)](http://isitmaintained.com/project/apache/rocketmq-client-go "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/apache/rocketmq-client-go.svg)](http://isitmaintained.com/project/apache/rocketmq-client-go "Percentage of issues still open")
-![Twitter Follow](https://img.shields.io/twitter/follow/ApacheRocketMQ?style=social)
+[![Twitter Follow](https://img.shields.io/twitter/follow/ApacheRocketMQ?style=social)](https://twitter.com/intent/follow?screen_name=ApacheRocketMQ)
 
 A product ready RocketMQ Client in pure go, which supports almost the full features of Apache RocketMQ, such as pub and sub messages, ACL, tracing and so on.
 

--- a/internal/remote/future.go
+++ b/internal/remote/future.go
@@ -53,7 +53,7 @@ func (r *ResponseFuture) executeInvokeCallback() {
 	})
 }
 
-func (r *ResponseFuture) waitResponse() (*RemotingCommand, error) {
+func (r *ResponseFuture) waitResponse(c *remotingClient) (*RemotingCommand, error) {
 	var (
 		cmd *RemotingCommand
 		err error
@@ -65,5 +65,8 @@ func (r *ResponseFuture) waitResponse() (*RemotingCommand, error) {
 		err = utils.ErrRequestTimeout
 		r.Err = err
 	}
+	
+	c.responseTable.Delete(r.Opaque)
+	
 	return cmd, err
 }

--- a/internal/remote/remote_client.go
+++ b/internal/remote/remote_client.go
@@ -194,7 +194,7 @@ func (c *remotingClient) processCMD(cmd *RemotingCommand, r *tcpConnWrapper) {
 	if cmd.isResponseType() {
 		resp, exist := c.responseTable.Load(cmd.Opaque)
 		if exist {
-			//c.responseTable.Delete(cmd.Opaque)
+			// c.responseTable.Delete(cmd.Opaque)
 			responseFuture := resp.(*ResponseFuture)
 			go primitive.WithRecover(func() {
 				responseFuture.ResponseCommand = cmd

--- a/internal/remote/remote_client.go
+++ b/internal/remote/remote_client.go
@@ -194,7 +194,6 @@ func (c *remotingClient) processCMD(cmd *RemotingCommand, r *tcpConnWrapper) {
 	if cmd.isResponseType() {
 		resp, exist := c.responseTable.Load(cmd.Opaque)
 		if exist {
-			// c.responseTable.Delete(cmd.Opaque)
 			responseFuture := resp.(*ResponseFuture)
 			go primitive.WithRecover(func() {
 				responseFuture.ResponseCommand = cmd

--- a/producer/selector.go
+++ b/producer/selector.go
@@ -44,6 +44,7 @@ func (manualQueueSelector) Select(message *primitive.Message, queues []*primitiv
 
 // randomQueueSelector choose a random queue each time.
 type randomQueueSelector struct {
+	mux    sync.Mutex
 	rander *rand.Rand
 }
 
@@ -53,8 +54,10 @@ func NewRandomQueueSelector() QueueSelector {
 	return s
 }
 
-func (r randomQueueSelector) Select(message *primitive.Message, queues []*primitive.MessageQueue) *primitive.MessageQueue {
+func (r *randomQueueSelector) Select(message *primitive.Message, queues []*primitive.MessageQueue) *primitive.MessageQueue {
+	r.mux.Lock()
 	i := r.rander.Intn(len(queues))
+	r.mux.Unlock()
 	return queues[i]
 }
 


### PR DESCRIPTION
## What is the purpose of the change

ISSUE #646

## Brief changelog

- 网络异常可能会导致receiveResponse收不到响应，responseTable中的数据会越来越多（泄漏）。
- InvokeSync不会有这种问题，但是为了和InvokeAsync保持一致，做了统一修改。
- 修改为在waitResponse时从responseTable中删除ResponseFuture，processCMD收到响应后不再删除。

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
