### PR TITLE
[ISSUE #659] make consumeMessageBatchMaxSize default value consistent with java client

### DIFF
--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -498,7 +498,7 @@ func (pc *pushConsumer) validate() {
 
 	if pc.option.ConsumeMessageBatchMaxSize < 1 || pc.option.ConsumeMessageBatchMaxSize > 1024 {
 		if pc.option.ConsumeMessageBatchMaxSize == 0 {
-			pc.option.ConsumeMessageBatchMaxSize = 512
+			pc.option.ConsumeMessageBatchMaxSize = 1
 		} else {
 			rlog.Error("option.ConsumeMessageBatchMaxSize out of range [1, 1024]", nil)
 		}


### PR DESCRIPTION
## What is the purpose of the change

issue #659 

## Brief changelog

make consumeMessageBatchMaxSize default value consistent with java client

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
