### PR TITLE
[ISSUE 672] gracefully shutdown push consumer, waiting until all active consuming finish

### DIFF
--- a/api.go
+++ b/api.go
@@ -55,7 +55,7 @@ type PushConsumer interface {
 	Start() error
 
 	// Shutdown the PullConsumer, all offset of MessageQueue will be sync to broker before process exit
-	Shutdown() error
+	Shutdown(ctx context.Context) error
 	// Subscribe a topic for consuming
 	Subscribe(topic string, selector consumer.MessageSelector,
 		f func(context.Context, ...*primitive.MessageExt) (consumer.ConsumeResult, error)) error

--- a/benchmark/consumer.go
+++ b/benchmark/consumer.go
@@ -168,7 +168,9 @@ func (bc *consumerBenchmark) consumeMsg(stati *statiBenchmarkConsumerSnapshot, e
 	c.Start()
 	select {
 	case <-exit:
-		c.Shutdown()
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		c.Shutdown(ctx)
 		return
 	}
 }

--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -249,6 +249,6 @@ func (c *defaultPullConsumer) CurrentOffset(queue *primitive.MessageQueue) (int6
 }
 
 // Shutdown close defaultConsumer, refuse new request.
-func (c *defaultPullConsumer) Shutdown() error {
-	return c.defaultConsumer.shutdown()
+func (c *defaultPullConsumer) Shutdown(ctx context.Context) error {
+	return c.defaultConsumer.shutdown(ctx)
 }

--- a/examples/consumer/acl/main.go
+++ b/examples/consumer/acl/main.go
@@ -57,7 +57,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("Shutdown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/broadcast/main.go
+++ b/examples/consumer/broadcast/main.go
@@ -50,7 +50,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("Shutdown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/delay/main.go
+++ b/examples/consumer/delay/main.go
@@ -53,7 +53,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("Shutdown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/interceptor/main.go
+++ b/examples/consumer/interceptor/main.go
@@ -50,7 +50,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("Shutdown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/namespace/main.go
+++ b/examples/consumer/namespace/main.go
@@ -58,7 +58,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("Shutdown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/orderly/main.go
+++ b/examples/consumer/orderly/main.go
@@ -53,7 +53,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("Shutdown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/retry/concurrent/main.go
+++ b/examples/consumer/retry/concurrent/main.go
@@ -74,7 +74,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("shundown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/retry/order/main.go
+++ b/examples/consumer/retry/order/main.go
@@ -69,7 +69,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("shundown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/simple/main.go
+++ b/examples/consumer/simple/main.go
@@ -51,7 +51,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("shutdown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/strategy/main.go
+++ b/examples/consumer/strategy/main.go
@@ -49,7 +49,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("shutdown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/tag/main.go
+++ b/examples/consumer/tag/main.go
@@ -51,7 +51,9 @@ func main() {
 		os.Exit(-1)
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("shutdown Consumer error: %s", err.Error())
 	}

--- a/examples/consumer/trace/main.go
+++ b/examples/consumer/trace/main.go
@@ -56,7 +56,9 @@ func main() {
 
 	}
 	time.Sleep(time.Hour)
-	err = c.Shutdown()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = c.Shutdown(ctx)
 	if err != nil {
 		fmt.Printf("shutdown Consumer error: %s", err.Error())
 	}


### PR DESCRIPTION
## What is the purpose of the change

Push consumer shutdown will wait until all active consumings have complete. Note, this pr only supports consume currently, not orderly.

## Brief changelog

- add a new field `activeConsuming int` to `type defaultConsumer struct {`
- shutdown will finish when `activeConsuming int` is 0
- `activeConsuming int` will increase 1 when a new message process starts
- `activeConsuming int` will decrease 1 when a message has finished processing.
- add a context to shutdown(), so shutdown may terminate within a predefined timeout.

## Verifying this change

Based on my test, I see 

```
smiletrl@Rulins-MacBook-Pro yuanyi-api % go run service.order/cmd/main.go 
[POP] 2021/05/30 13:28:11 warn - ignoring file schema.sql because it does not match the migration file pattern
[POP] 2021/05/30 13:28:11 info - Migrations already up to date, nothing to apply
[POP] 2021/05/30 13:28:11 info - 0.0099 seconds

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.2.1
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\

⇨ http server started on [::]:1324
subscribe start
subscribe start
subscribe start
^Ccontrol c has entered
echo server stop: http: Server closed 
echo shutdown
subscribe complete: tag: payment_succeed, key: a0f3614c-96d7-4a57-8d1c-4255e7494e29 d4c0b9df-095e-4ef2-bec0-71e286a32b6f 122333 , and resonsume times: 0, and time 2021-05-30 13:28:16.765764 +0800 CST m=+5.212330369

subscribe complete: tag: payment_succeed, key: cc71241f-b7c7-440e-8304-14140b6a6723 f3b46be4-162e-40e0-8a4c-392ad22f9de2 122333 , and resonsume times: 0, and time 2021-05-30 13:28:19.590724 +0800 CST m=+8.037273904

subscribe complete: tag: payment_succeed, key: a706a258-e094-4270-8418-0160b81822dd 34255528-2262-4218-8eea-08166fbc2892 122333 , and resonsume times: 0, and time 2021-05-30 13:28:20.0922 +0800 CST m=+8.538746669

{"level":"error","ts":1622352500.0957801,"caller":"logger/mock.go:32","msg":"Panic Recover in order main"}
```

So I have entered `Control C`, the http server has shut down, but the consumer keeps running until subscribe complete, and then the program exits.

More details can be found at [issue 672](https://github.com/apache/rocketmq-client-go/issues/672)

