### PR TITLE
[ISSUE #688] fix type assert panic

### DIFF
--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -144,7 +144,7 @@ func (c *defaultPullConsumer) getNextQueueOf(topic string) *primitive.MessageQue
 	v, exist := queueCounterTable.Load(topic)
 	if !exist {
 		index = -1
-		queueCounterTable.Store(topic, 0)
+		queueCounterTable.Store(topic, int64(0))
 	} else {
 		index = v.(int64)
 	}

--- a/internal/remote/remote_client_test.go
+++ b/internal/remote/remote_client_test.go
@@ -77,7 +77,8 @@ func TestResponseFutureTimeout(t *testing.T) {
 }
 
 func TestResponseFutureWaitResponse(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), time.Duration(1000))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(1000))
+	defer cancel()
 	future := NewResponseFuture(ctx, 10, nil)
 	if _, err := future.waitResponse(); err != utils.ErrRequestTimeout {
 		t.Errorf("wrong ResponseFuture waitResponse. want=%v, got=%v",
@@ -289,7 +290,8 @@ func TestInvokeAsyncTimeout(t *testing.T) {
 	clientSend.Add(1)
 	go func() {
 		clientSend.Wait()
-		ctx, _ := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(10*time.Second))
+		defer cancel()
 		err := client.InvokeAsync(ctx, addr, clientSendRemtingCommand,
 			func(r *ResponseFuture) {
 				assert.NotNil(t, r.Err)

--- a/internal/route.go
+++ b/internal/route.go
@@ -351,12 +351,14 @@ func (s *namesrvs) queryTopicRouteInfoFromServer(topic string) (*TopicRouteData,
 
 	for i := 0; i < s.Size(); i++ {
 		rc := remote.NewRemotingCommand(ReqGetRouteInfoByTopic, request, nil)
-		ctx, _ := context.WithTimeout(context.Background(), requestTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		response, err = s.nameSrvClient.InvokeSync(ctx, s.getNameServerAddress(), rc)
 
 		if err == nil {
+			cancel()
 			break
 		}
+		cancel()
 	}
 	if err != nil {
 		rlog.Error("connect to namesrv failed.", map[string]interface{}{

--- a/internal/trace.go
+++ b/internal/trace.go
@@ -458,7 +458,8 @@ func (td *traceDispatcher) sendTraceDataByMQ(keySet Keyset, regionID string, dat
 	}
 
 	var req = td.buildSendRequest(mq, msg)
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	err := td.cli.InvokeAsync(ctx, addr, req, func(command *remote.RemotingCommand, e error) {
 		resp := primitive.NewSendResult()
 		if e != nil {

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -241,7 +241,9 @@ func (p *defaultProducer) sendAsync(ctx context.Context, msg *primitive.Message,
 		return errors.Errorf("topic=%s route info not found", mq.Topic)
 	}
 
-	ctx, _ = context.WithTimeout(ctx, 3*time.Second)
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 	return p.client.InvokeAsync(ctx, addr, p.buildSendRequest(mq, msg), func(command *remote.RemotingCommand, err error) {
 		resp := primitive.NewSendResult()
 		if err != nil {


### PR DESCRIPTION
The `sync.Map` store the value 0, its type is `int`, but in that code before fixed, the value `Load` by `sync.Map` is asserted as `int64`, so cause the type assert panic.