### PR TITLE
[ISSUE #736][ISSUE #730]Add fault tolerance for message producing.

### DIFF
--- a/latency/fault_strategy.go
+++ b/latency/fault_strategy.go
@@ -1,0 +1,39 @@
+package latency
+
+// latency range max limit milliseconds
+var latencyMaxList = []int64{50, 100, 550, 1000, 2000, 3000, 15000}
+
+// mapped isolate milliseconds with latency range
+var isolationDurationList = []int64{0, 0, 30000, 60000, 120000, 180000, 600000}
+
+var isolationDefaultLatency int64 = 30000
+
+type FaultStrategy struct {
+	LatencyFaultHandler latencyFaultHandler
+}
+
+func NewDefaultFaultStrategy() *FaultStrategy {
+	var lft latencyFaultTolerance
+	return &FaultStrategy{LatencyFaultHandler: &lft}
+}
+
+// update broker latency info by fault strategy
+func (fs *FaultStrategy) UpdateFaultItem(brokerName string, currentLatency int64, isolation bool) {
+
+	if isolation {
+		currentLatency = isolationDefaultLatency
+	}
+	isolationDuration := computeIsolationDuration(currentLatency)
+	fs.LatencyFaultHandler.UpdateFaultItem(brokerName, currentLatency, isolationDuration)
+
+}
+
+// compute the duration of broker isolation from rage
+func computeIsolationDuration(currentLatency int64) int64 {
+	for i := len(latencyMaxList) - 1; i >= 0; i-- {
+		if currentLatency >= latencyMaxList[i] {
+			return isolationDurationList[i]
+		}
+	}
+	return 0
+}

--- a/latency/fault_strategy_test.go
+++ b/latency/fault_strategy_test.go
@@ -1,0 +1,71 @@
+package latency
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFaultStrategy_UpdateFaultItem(t *testing.T) {
+
+	var lft latencyFaultTolerance
+
+	type fields struct {
+		LatencyFaultHandler latencyFaultHandler
+	}
+	type args struct {
+		brokerName     string
+		currentLatency int64
+		isolation      bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{name: "level1", fields: struct{ LatencyFaultHandler latencyFaultHandler }{&lft}, args: args{"broker-a", 20, true}},
+		{name: "level2", fields: struct{ LatencyFaultHandler latencyFaultHandler }{&lft}, args: args{"broker-a", 90, true}},
+		{name: "level3", fields: struct{ LatencyFaultHandler latencyFaultHandler }{&lft}, args: args{"broker-a", 500, true}},
+		{name: "level4", fields: struct{ LatencyFaultHandler latencyFaultHandler }{&lft}, args: args{"broker-a", 800, false}},
+		{name: "level5", fields: struct{ LatencyFaultHandler latencyFaultHandler }{&lft}, args: args{"broker-a", 1500, false}},
+		{name: "level6", fields: struct{ LatencyFaultHandler latencyFaultHandler }{&lft}, args: args{"broker-a", 2500, false}},
+		{name: "level7", fields: struct{ LatencyFaultHandler latencyFaultHandler }{&lft}, args: args{"broker-a", 3500, false}},
+		{name: "level8", fields: struct{ LatencyFaultHandler latencyFaultHandler }{&lft}, args: args{"broker-a", 30000, false}},
+		{name: "level9", fields: struct{ LatencyFaultHandler latencyFaultHandler }{&lft}, args: args{"broker-a", 20, true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := &FaultStrategy{
+				LatencyFaultHandler: tt.fields.LatencyFaultHandler,
+			}
+			fs.UpdateFaultItem(tt.args.brokerName, tt.args.currentLatency, tt.args.isolation)
+			assert.False(t, fs.LatencyFaultHandler.IsAvailable(tt.args.brokerName))
+		})
+	}
+}
+
+func Test_computeIsolationDuration(t *testing.T) {
+	type args struct {
+		currentLatency int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want int64
+	}{
+		{name: "level1", args: struct{ currentLatency int64 }{currentLatency: 20}, want: isolationDurationList[0]},
+		{name: "level2", args: struct{ currentLatency int64 }{currentLatency: 500}, want: isolationDurationList[1]},
+		{name: "level3", args: struct{ currentLatency int64 }{currentLatency: 800}, want: isolationDurationList[2]},
+		{name: "level4", args: struct{ currentLatency int64 }{currentLatency: 1500}, want: isolationDurationList[3]},
+		{name: "level5", args: struct{ currentLatency int64 }{currentLatency: 2500}, want: isolationDurationList[4]},
+		{name: "level6", args: struct{ currentLatency int64 }{currentLatency: 3500}, want: isolationDurationList[5]},
+		{name: "level7", args: struct{ currentLatency int64 }{currentLatency: 20000}, want: isolationDurationList[len(isolationDurationList)-1]},
+		{name: "level8", args: struct{ currentLatency int64 }{currentLatency: isolationDefaultLatency}, want: isolationDurationList[len(isolationDurationList)-1]},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := computeIsolationDuration(tt.args.currentLatency); got != tt.want {
+				t.Errorf("computeIsolationDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/latency/latency_fault_handler.go
+++ b/latency/latency_fault_handler.go
@@ -1,0 +1,82 @@
+package latency
+
+import (
+	"go.uber.org/atomic"
+	"sync"
+	"time"
+)
+
+// interface for handle mq fault
+type latencyFaultHandler interface {
+
+	// update wrong item when catch it
+	UpdateFaultItem(brokerName string, currentLatency int64, isolationDuration int64)
+
+	IsAvailable(brokerName string) bool
+
+	Remove(brokerName string)
+
+	PickOneAtLeast() string
+}
+
+// fault tolerance handler
+type latencyFaultTolerance struct {
+
+	// brokerName -> faultItem
+	faultItemMap sync.Map
+}
+
+type faultItem struct {
+	name string
+
+	currentLatency *atomic.Int64
+
+	// timestamp to release broker
+	releasedTimestamp *atomic.Int64
+}
+
+// update broker latency info
+func (lft *latencyFaultTolerance) UpdateFaultItem(brokerName string, currentLatency int64, isolationDuration int64) {
+	fi, exist := lft.faultItemMap.Load(brokerName)
+	if exist {
+		faultItem := fi.(faultItem)
+		faultItem.currentLatency.Store(currentLatency)
+		faultItem.releasedTimestamp.Store(time.Now().UnixNano()/int64(time.Millisecond) + isolationDuration)
+	} else {
+		lft.faultItemMap.LoadOrStore(brokerName, faultItem{
+			name:              brokerName,
+			currentLatency:    atomic.NewInt64(currentLatency),
+			releasedTimestamp: atomic.NewInt64(time.Now().UnixNano()/int64(time.Millisecond) + isolationDuration),
+		})
+	}
+}
+
+// check broker is available,when
+func (lft *latencyFaultTolerance) IsAvailable(brokerName string) bool {
+	fi, exist := lft.faultItemMap.Load(brokerName)
+	if exist {
+		return time.Now().UnixNano()/int64(time.Millisecond)-fi.(faultItem).releasedTimestamp.Load() >= 0
+	} else {
+		return true
+	}
+}
+
+func (lft *latencyFaultTolerance) Remove(brokerName string) {
+	lft.faultItemMap.Delete(brokerName)
+}
+
+// pick the earliest isolate broker
+func (lft *latencyFaultTolerance) PickOneAtLeast() string {
+
+	var minIsolateTimestamp int64 = 0
+	var luckyBrokerName = ""
+	lft.faultItemMap.Range(func(brokerName, fi interface{}) bool {
+		releasedTimestamp := fi.(faultItem).releasedTimestamp.Load()
+		if minIsolateTimestamp == 0 || minIsolateTimestamp > releasedTimestamp {
+			minIsolateTimestamp = releasedTimestamp
+			luckyBrokerName = brokerName.(string)
+		}
+		return true
+	})
+	return luckyBrokerName
+}

--- a/latency/latency_fault_handler_test.go
+++ b/latency/latency_fault_handler_test.go
@@ -1,0 +1,164 @@
+package latency
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+	"sync"
+	"testing"
+	"time"
+)
+
+func Test_latencyFaultTolerance_UpdateFaultItem(t *testing.T) {
+
+	var fim sync.Map
+	fim.Store("broker-a", faultItem{
+		name:              "broker-a",
+		currentLatency:    atomic.NewInt64(300),
+		releasedTimestamp: atomic.NewInt64(3000 + time.Now().UnixNano()/1e6),
+	})
+
+	type fields struct {
+		faultItemMap sync.Map
+	}
+	type args struct {
+		brokerName        string
+		currentLatency    int64
+		isolationDuration int64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{name: "newFaultItem", fields: struct{ faultItemMap sync.Map }{}, args: args{"broker-a", 3000, 3000}},
+		{name: "existFaultItem", fields: struct{ faultItemMap sync.Map }{fim}, args: args{"broker-a", 200, 10000}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lft := &latencyFaultTolerance{
+				faultItemMap: tt.fields.faultItemMap,
+			}
+			flm, exist := lft.faultItemMap.Load(tt.args.brokerName)
+			if tt.name == "newFaultItem" {
+				assert.False(t, exist)
+			} else if tt.name == "existFaultItem" {
+				assert.True(t, exist)
+			}
+			lft.UpdateFaultItem(tt.args.brokerName, tt.args.currentLatency, tt.args.isolationDuration)
+			flm, exist = lft.faultItemMap.Load(tt.args.brokerName)
+			assert.True(t, exist)
+			assert.Equal(t, tt.args.currentLatency, flm.(faultItem).currentLatency.Load())
+			assert.True(t, tt.args.isolationDuration+time.Now().UnixNano()/1e6 >= flm.(faultItem).releasedTimestamp.Load())
+		})
+	}
+}
+
+func Test_latencyFaultTolerance_IsAvailable(t *testing.T) {
+
+	var fim sync.Map
+	fim.Store("broker-a", faultItem{
+		name:              "broker-a",
+		currentLatency:    atomic.NewInt64(300),
+		releasedTimestamp: atomic.NewInt64(30000 + time.Now().UnixNano()/1e6),
+	})
+
+	type fields struct {
+		faultItemMap sync.Map
+	}
+	type args struct {
+		brokerName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{name: "notAvailable", fields: struct{ faultItemMap sync.Map }{fim}, args: args{"broker-a"}, want: false},
+		{name: "available", fields: struct{ faultItemMap sync.Map }{fim}, args: args{"broker-b"}, want: true}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lft := &latencyFaultTolerance{
+				faultItemMap: tt.fields.faultItemMap,
+			}
+			if got := lft.IsAvailable(tt.args.brokerName); got != tt.want {
+				t.Errorf("IsAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_latencyFaultTolerance_Remove(t *testing.T) {
+
+	var fim sync.Map
+	fim.Store("broker-a", faultItem{
+		name:              "broker-a",
+		currentLatency:    atomic.NewInt64(300),
+		releasedTimestamp: atomic.NewInt64(30000 + time.Now().UnixNano()/1e6),
+	})
+
+	type fields struct {
+		faultItemMap sync.Map
+	}
+	type args struct {
+		brokerName string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		{name: "removeBrokerA", fields: struct{ faultItemMap sync.Map }{}, args: args{"broker-a"}},
+		{name: "removeFromEmptyMap", fields: struct{ faultItemMap sync.Map }{fim}, args: args{"broker-b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lft := &latencyFaultTolerance{
+				faultItemMap: tt.fields.faultItemMap,
+			}
+			_, exist := lft.faultItemMap.Load(tt.args.brokerName)
+			lft.faultItemMap.Delete(tt.args.brokerName)
+			_, exist = lft.faultItemMap.Load(tt.args.brokerName)
+			assert.False(t, exist)
+		})
+	}
+}
+
+func Test_latencyFaultTolerance_PickOneAtLeast(t *testing.T) {
+
+	var fim sync.Map
+	fim.Store("broker-a", faultItem{
+		name:              "broker-a",
+		currentLatency:    atomic.NewInt64(300),
+		releasedTimestamp: atomic.NewInt64(30000 + time.Now().UnixNano()/1e6),
+	})
+	fim.Store("broker-b", faultItem{
+		name:              "broker-b",
+		currentLatency:    atomic.NewInt64(300),
+		releasedTimestamp: atomic.NewInt64(60000 + time.Now().UnixNano()/1e6),
+	})
+
+	var fimEmpty sync.Map
+
+	type fields struct {
+		faultItemMap sync.Map
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{name: "pickEarliestBroker", fields: struct{ faultItemMap sync.Map }{fim}, want: "broker-a"},
+		{name: "pickEmpty", fields: struct{ faultItemMap sync.Map }{fimEmpty}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lft := &latencyFaultTolerance{
+				faultItemMap: tt.fields.faultItemMap,
+			}
+			if got := lft.PickOneAtLeast(); got != tt.want {
+				t.Errorf("PickOneAtLeast() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add message send timeout check
Fix it would always failed when one of the broker from cluster was busy or down when producing message.

## What is the purpose of the change

issiue #736 #730 

## Brief changelog

According to java sdk, add fault stratety for broker selecting at message producing

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [✅] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [✅] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [✅] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [✅] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
