### PR TITLE
add imports-formatter

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -21,7 +21,9 @@ import (
 	"context"
 	"sync"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/api.go
+++ b/api.go
@@ -19,9 +19,11 @@ package rocketmq
 
 import (
 	"context"
-	"github.com/apache/rocketmq-client-go/v2/errors"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/consumer"
+	"github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"
 )

--- a/benchmark/consumer.go
+++ b/benchmark/consumer.go
@@ -21,16 +21,19 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/apache/rocketmq-client-go/v2"
-	"github.com/apache/rocketmq-client-go/v2/consumer"
-	"github.com/apache/rocketmq-client-go/v2/primitive"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"os"
 	"os/signal"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2"
+	"github.com/apache/rocketmq-client-go/v2/consumer"
+	"github.com/apache/rocketmq-client-go/v2/primitive"
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 type statiBenchmarkConsumerSnapshot struct {

--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -19,8 +19,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"os"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 type command interface {

--- a/benchmark/message.go
+++ b/benchmark/message.go
@@ -17,7 +17,9 @@
 
 package main
 
-import "strings"
+import (
+	"strings"
+)
 
 var (
 	longText    = ""

--- a/benchmark/producer.go
+++ b/benchmark/producer.go
@@ -20,16 +20,19 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/apache/rocketmq-client-go/v2"
-	"github.com/apache/rocketmq-client-go/v2/primitive"
-	"github.com/apache/rocketmq-client-go/v2/producer"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"os"
 	"os/signal"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2"
+	"github.com/apache/rocketmq-client-go/v2/primitive"
+	"github.com/apache/rocketmq-client-go/v2/producer"
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 type statiBenchmarkProducerSnapshot struct {

--- a/benchmark/stable.go
+++ b/benchmark/stable.go
@@ -19,12 +19,15 @@ package main
 
 import (
 	"flag"
-	"github.com/apache/rocketmq-client-go/v2/errors"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 type stableTest struct {

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -20,18 +20,22 @@ package consumer
 import (
 	"context"
 	"fmt"
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+)
 
+import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/tidwall/gjson"
+)
 
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"

--- a/consumer/consumer_test.go
+++ b/consumer/consumer_test.go
@@ -21,11 +21,17 @@ import (
 	"sync"
 	"testing"
 	"time"
+)
 
+import (
 	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
-	"github.com/stretchr/testify/assert"
 
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/stretchr/testify/assert"
+)
+
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/consumer/interceptor.go
+++ b/consumer/interceptor.go
@@ -20,7 +20,9 @@ package consumer
 import (
 	"context"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/consumer/lock.go
+++ b/consumer/lock.go
@@ -19,7 +19,9 @@ package consumer
 
 import (
 	"sync"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )
 

--- a/consumer/mock_offset_store.go
+++ b/consumer/mock_offset_store.go
@@ -23,9 +23,14 @@ package consumer
 
 import (
 	reflect "reflect"
+)
 
-	primitive "github.com/apache/rocketmq-client-go/v2/primitive"
+import (
 	gomock "github.com/golang/mock/gomock"
+)
+
+import (
+	primitive "github.com/apache/rocketmq-client-go/v2/primitive"
 )
 
 // MockOffsetStore is a mock of OffsetStore interface

--- a/consumer/offset_store.go
+++ b/consumer/offset_store.go
@@ -25,13 +25,18 @@ import (
 	"strconv"
 	"sync"
 	"time"
+)
 
+import (
+	jsoniter "github.com/json-iterator/go"
+)
+
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/rlog"
-	jsoniter "github.com/json-iterator/go"
 )
 
 type readType int

--- a/consumer/offset_store_test.go
+++ b/consumer/offset_store_test.go
@@ -20,12 +20,18 @@ package consumer
 import (
 	"path/filepath"
 	"testing"
+)
 
+import (
+	"github.com/golang/mock/gomock"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
-	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestNewLocalFileOffsetStore(t *testing.T) {

--- a/consumer/option.go
+++ b/consumer/option.go
@@ -19,7 +19,9 @@ package consumer
 
 import (
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )

--- a/consumer/process_queue.go
+++ b/consumer/process_queue.go
@@ -22,12 +22,17 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+)
 
+import (
 	"github.com/emirpasic/gods/maps/treemap"
 	"github.com/emirpasic/gods/utils"
 	gods_util "github.com/emirpasic/gods/utils"
-	uatomic "go.uber.org/atomic"
 
+	uatomic "go.uber.org/atomic"
+)
+
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/rlog"

--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -20,12 +20,16 @@ package consumer
 import (
 	"context"
 	"fmt"
-	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 	"sync"
 	"sync/atomic"
+)
 
+import (
 	"github.com/pkg/errors"
+)
 
+import (
+	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/rlog"

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -20,16 +20,20 @@ package consumer
 import (
 	"context"
 	"fmt"
-	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 	"math"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+)
 
+import (
 	"github.com/pkg/errors"
+)
 
+import (
+	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
@@ -45,7 +49,6 @@ import (
 // See quick start/Consumer in the example module for a typical usage.
 //
 // <strong>Thread Safety:</strong> After initialization, the instance can be regarded as thread-safe.
-
 const (
 	Mb = 1024 * 1024
 )

--- a/consumer/push_consumer_test.go
+++ b/consumer/push_consumer_test.go
@@ -19,13 +19,19 @@ package consumer
 
 import (
 	"context"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"testing"
+)
 
+import (
+	"github.com/golang/mock/gomock"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
-	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 func mockB4Start(c *pushConsumer) {

--- a/consumer/statistics.go
+++ b/consumer/statistics.go
@@ -23,7 +23,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/rlog"
 )

--- a/consumer/strategy.go
+++ b/consumer/strategy.go
@@ -19,9 +19,13 @@ package consumer
 
 import (
 	"strings"
+)
 
+import (
 	"github.com/stathat/consistent"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/rlog"
@@ -40,7 +44,6 @@ import (
 // Use Message QueueID specified
 // Computer room Hashing queue algorithm, such as Alipay logic room
 // Consistent Hashing queue algorithm
-
 type AllocateStrategy func(string, string, []*primitive.MessageQueue, []string) []*primitive.MessageQueue
 
 func AllocateByAveragely(consumerGroup, currentCID string, mqAll []*primitive.MessageQueue,

--- a/consumer/strategy_test.go
+++ b/consumer/strategy_test.go
@@ -18,11 +18,16 @@ limitations under the License.
 package consumer
 
 import (
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"testing"
+)
 
-	"github.com/apache/rocketmq-client-go/v2/primitive"
+import (
 	. "github.com/smartystreets/goconvey/convey"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/primitive"
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 func TestAllocateByAveragely(t *testing.T) {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -17,7 +17,9 @@ limitations under the License.
 
 package errors
 
-import "errors"
+import (
+	"errors"
+)
 
 var (
 	ErrRequestTimeout    = errors.New("request timeout")

--- a/examples/admin/topic/main.go
+++ b/examples/admin/topic/main.go
@@ -20,7 +20,9 @@ package main
 import (
 	"context"
 	"fmt"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/admin"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )

--- a/examples/consumer/acl/main.go
+++ b/examples/consumer/acl/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/broadcast/main.go
+++ b/examples/consumer/broadcast/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/delay/main.go
+++ b/examples/consumer/delay/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/interceptor/main.go
+++ b/examples/consumer/interceptor/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/namespace/main.go
+++ b/examples/consumer/namespace/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/orderly/main.go
+++ b/examples/consumer/orderly/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/pull/main.go
+++ b/examples/consumer/pull/main.go
@@ -20,11 +20,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
+	"github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/rlog"
 )

--- a/examples/consumer/retry/concurrent/main.go
+++ b/examples/consumer/retry/concurrent/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/retry/order/main.go
+++ b/examples/consumer/retry/order/main.go
@@ -27,7 +27,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/simple/main.go
+++ b/examples/consumer/simple/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/strategy/main.go
+++ b/examples/consumer/strategy/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/tag/main.go
+++ b/examples/consumer/tag/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/consumer/trace/main.go
+++ b/examples/consumer/trace/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/consumer"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/examples/producer/acl/main.go
+++ b/examples/producer/acl/main.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/examples/producer/async/main.go
+++ b/examples/producer/async/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"sync"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/examples/producer/batch/main.go
+++ b/examples/producer/batch/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/examples/producer/delay/main.go
+++ b/examples/producer/delay/main.go
@@ -21,7 +21,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/examples/producer/interceptor/main.go
+++ b/examples/producer/interceptor/main.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/examples/producer/namespace/main.go
+++ b/examples/producer/namespace/main.go
@@ -22,7 +22,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/examples/producer/simple/main.go
+++ b/examples/producer/simple/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/examples/producer/tag/main.go
+++ b/examples/producer/tag/main.go
@@ -21,7 +21,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/examples/producer/trace/main.go
+++ b/examples/producer/trace/main.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"os"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/examples/producer/transaction/main.go
+++ b/examples/producer/transaction/main.go
@@ -25,7 +25,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/apache/rocketmq-client-go/v2
 go 1.13
 
 require (
+    github.com/dubbogo/tools v1.0.9 // indirect
 	github.com/emirpasic/gods v1.12.0
 	github.com/golang/mock v1.3.1
 	github.com/json-iterator/go v1.1.9

--- a/internal/callback.go
+++ b/internal/callback.go
@@ -19,7 +19,9 @@ package internal
 
 import (
 	"net"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )
 

--- a/internal/client.go
+++ b/internal/client.go
@@ -21,14 +21,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 	"net"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+)
 
+import (
+	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
@@ -119,7 +121,7 @@ type ClientOptions struct {
 
 func (opt *ClientOptions) ChangeInstanceNameToPID() {
 	if opt.InstanceName == "DEFAULT" {
-		opt.InstanceName = strconv.Itoa(os.Getpid())
+		opt.InstanceName = fmt.Sprintf("%d#%d", os.Getpid(), time.Now().UnixNano())
 	}
 }
 

--- a/internal/mock_client.go
+++ b/internal/mock_client.go
@@ -25,9 +25,13 @@ import (
 	"context"
 	"reflect"
 	"time"
+)
 
+import (
 	"github.com/golang/mock/gomock"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )

--- a/internal/mock_namesrv.go
+++ b/internal/mock_namesrv.go
@@ -22,9 +22,14 @@ package internal
 
 import (
 	reflect "reflect"
+)
 
-	primitive "github.com/apache/rocketmq-client-go/v2/primitive"
+import (
 	gomock "github.com/golang/mock/gomock"
+)
+
+import (
+	primitive "github.com/apache/rocketmq-client-go/v2/primitive"
 )
 
 // MockNamesrvs is a mock of Namesrvs interface

--- a/internal/model.go
+++ b/internal/model.go
@@ -21,15 +21,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/tidwall/gjson"
 	"sort"
 	"strconv"
 	"strings"
+)
 
+import (
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/tidwall/gjson"
+)
+
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/rlog"
-	jsoniter "github.com/json-iterator/go"
 )
 
 type FindBrokerResult struct {

--- a/internal/model_test.go
+++ b/internal/model_test.go
@@ -19,15 +19,20 @@ package internal
 
 import (
 	"encoding/json"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"strings"
 	"testing"
+)
 
+import (
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/tidwall/gjson"
 
+	"github.com/tidwall/gjson"
+)
+
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 func TestHeartbeatData(t *testing.T) {

--- a/internal/namesrv.go
+++ b/internal/namesrv.go
@@ -23,7 +23,9 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )

--- a/internal/namesrv_test.go
+++ b/internal/namesrv_test.go
@@ -19,18 +19,23 @@ package internal
 
 import (
 	"fmt"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"net"
 	"net/http"
 	"os"
 	"strings"
 	"sync"
 	"testing"
+)
 
-	"github.com/apache/rocketmq-client-go/v2/primitive"
-
+import (
 	. "github.com/smartystreets/goconvey/convey"
+
 	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/primitive"
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 // TestSelector test roundrobin selector in namesrv

--- a/internal/remote/codec.go
+++ b/internal/remote/codec.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"io"
 	"sync/atomic"
+)
 
+import (
 	jsoniter "github.com/json-iterator/go"
 )
 

--- a/internal/remote/codec_test.go
+++ b/internal/remote/codec_test.go
@@ -18,15 +18,20 @@ package remote
 
 import (
 	"encoding/json"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"math/rand"
 	"reflect"
 	"testing"
 	"unsafe"
+)
 
+import (
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 type testHeader struct {

--- a/internal/remote/future.go
+++ b/internal/remote/future.go
@@ -19,8 +19,11 @@ package remote
 
 import (
 	"context"
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"sync"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
 )
 
 // ResponseFuture

--- a/internal/remote/interceptor.go
+++ b/internal/remote/interceptor.go
@@ -25,7 +25,9 @@ import (
 	"hash"
 	"sort"
 	"strings"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )
 

--- a/internal/remote/interceptor_test.go
+++ b/internal/remote/interceptor_test.go
@@ -19,7 +19,9 @@ package remote
 
 import (
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/remote/mock_remote_client.go
+++ b/internal/remote/mock_remote_client.go
@@ -23,9 +23,14 @@ package remote
 import (
 	context "context"
 	reflect "reflect"
+)
 
-	primitive "github.com/apache/rocketmq-client-go/v2/primitive"
+import (
 	gomock "github.com/golang/mock/gomock"
+)
+
+import (
+	primitive "github.com/apache/rocketmq-client-go/v2/primitive"
 )
 
 // MockRemotingClient is a mock of RemotingClient interface

--- a/internal/remote/remote_client.go
+++ b/internal/remote/remote_client.go
@@ -24,9 +24,10 @@ import (
 	"io"
 	"net"
 	"sync"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/primitive"
-
 	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 

--- a/internal/remote/remote_client_test.go
+++ b/internal/remote/remote_client_test.go
@@ -19,15 +19,20 @@ package remote
 import (
 	"bytes"
 	"context"
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"math/rand"
 	"net"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
 )
 
 func TestNewResponseFuture(t *testing.T) {

--- a/internal/remote/tcp_conn.go
+++ b/internal/remote/tcp_conn.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"net"
 	"sync"
+)
 
+import (
 	"go.uber.org/atomic"
 )
 

--- a/internal/route.go
+++ b/internal/route.go
@@ -19,7 +19,6 @@ package internal
 
 import (
 	"context"
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -27,10 +26,16 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+)
 
+import (
 	jsoniter "github.com/json-iterator/go"
-	"github.com/tidwall/gjson"
 
+	"github.com/tidwall/gjson"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/internal/route_test.go
+++ b/internal/route_test.go
@@ -19,14 +19,20 @@ package internal
 
 import (
 	"context"
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"sync"
 	"testing"
+)
 
+import (
 	"github.com/golang/mock/gomock"
-	. "github.com/smartystreets/goconvey/convey"
-	"github.com/stretchr/testify/assert"
 
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )

--- a/internal/trace.go
+++ b/internal/trace.go
@@ -26,9 +26,13 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+)
 
+import (
 	"github.com/pkg/errors"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/rlog"

--- a/internal/trace_test.go
+++ b/internal/trace_test.go
@@ -19,10 +19,16 @@ package internal
 
 import (
 	"testing"
+)
 
-	"github.com/apache/rocketmq-client-go/v2/primitive"
+import (
 	. "github.com/smartystreets/goconvey/convey"
+
 	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/primitive"
 )
 
 func TestMarshal2Bean(t *testing.T) {

--- a/internal/utils/compression.go
+++ b/internal/utils/compression.go
@@ -20,9 +20,12 @@ package utils
 import (
 	"bytes"
 	"compress/zlib"
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"io/ioutil"
 	"sync"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
 )
 
 var zlibWriterPools []sync.Pool

--- a/internal/utils/net.go
+++ b/internal/utils/net.go
@@ -20,10 +20,13 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"net"
 	"strconv"
 	"time"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
 )
 
 var (

--- a/internal/utils/net_test.go
+++ b/internal/utils/net_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 
 package utils
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestLocalIP2(t *testing.T) {
 	t.Log(LocalIP)

--- a/internal/validators.go
+++ b/internal/validators.go
@@ -19,7 +19,9 @@ package internal
 
 import (
 	"regexp"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 

--- a/primitive/base.go
+++ b/primitive/base.go
@@ -18,9 +18,12 @@ limitations under the License.
 package primitive
 
 import (
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"regexp"
 	"strings"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
 )
 
 var (

--- a/primitive/base_test.go
+++ b/primitive/base_test.go
@@ -19,7 +19,9 @@ package primitive
 
 import (
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
 )
 

--- a/primitive/ctx.go
+++ b/primitive/ctx.go
@@ -23,7 +23,9 @@ package primitive
 import (
 	"context"
 	"math"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 

--- a/primitive/message.go
+++ b/primitive/message.go
@@ -27,7 +27,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 )
 

--- a/primitive/message_test.go
+++ b/primitive/message_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 
 package primitive
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestMessageID(t *testing.T) {
 	id := []byte("0AAF0895000078BF000000000009BB4A")

--- a/primitive/nsresolver.go
+++ b/primitive/nsresolver.go
@@ -25,7 +25,9 @@ import (
 	"path"
 	"strings"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 

--- a/primitive/nsresolver_test.go
+++ b/primitive/nsresolver_test.go
@@ -18,15 +18,20 @@ package primitive
 
 import (
 	"fmt"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
 	"strings"
 	"testing"
+)
 
+import (
 	. "github.com/smartystreets/goconvey/convey"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 func TestEnvResolver(t *testing.T) {

--- a/primitive/result_test.go
+++ b/primitive/result_test.go
@@ -19,8 +19,11 @@ package primitive
 
 import (
 	"testing"
+)
 
+import (
 	. "github.com/smartystreets/goconvey/convey"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/producer/interceptor.go
+++ b/producer/interceptor.go
@@ -23,7 +23,9 @@ package producer
 import (
 	"context"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/producer/option.go
+++ b/producer/option.go
@@ -19,7 +19,9 @@ package producer
 
 import (
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -21,14 +21,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
+)
 
+import (
 	"github.com/pkg/errors"
+)
 
+import (
+	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"

--- a/producer/producer_test.go
+++ b/producer/producer_test.go
@@ -19,12 +19,17 @@ package producer
 
 import (
 	"context"
-	"github.com/apache/rocketmq-client-go/v2/errors"
 	"testing"
+)
 
+import (
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/rocketmq-client-go/v2/errors"
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/internal/remote"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/producer/selector.go
+++ b/producer/selector.go
@@ -22,7 +22,9 @@ import (
 	"math/rand"
 	"sync"
 	"time"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )
 

--- a/producer/selector_test.go
+++ b/producer/selector_test.go
@@ -19,9 +19,13 @@ package producer
 
 import (
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
+)
 
+import (
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 )
 

--- a/rlog/log.go
+++ b/rlog/log.go
@@ -20,7 +20,9 @@ package rlog
 import (
 	"os"
 	"strings"
+)
 
+import (
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION

imports-formatter will split illegal format imports to three blocks:

the first import block is some built-in modules/packages in go language.
the second import block is some third party modules/packages.
the third import block is the modules/packages in this module.



