### PR TITLE
fix long time block when remote endpoint crash.

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -75,7 +75,7 @@ func NewAdmin(opts ...AdminOption) (Admin, error) {
 	for _, opt := range opts {
 		opt(defaultOpts)
 	}
-	namesrv, err := internal.NewNamesrv(defaultOpts.Resolver)
+	namesrv, err := internal.NewNamesrv(defaultOpts.Resolver, defaultOpts.RemotingClientConfig)
 	defaultOpts.Namesrv = namesrv
 	if err != nil {
 		return nil, err

--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -76,7 +76,7 @@ func NewPullConsumer(options ...Option) (*defaultPullConsumer, error) {
 		apply(&defaultOpts)
 	}
 
-	srvs, err := internal.NewNamesrv(defaultOpts.Resolver)
+	srvs, err := internal.NewNamesrv(defaultOpts.Resolver, defaultOpts.RemotingClientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "new Namesrv failed.")
 	}

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -77,7 +77,7 @@ func NewPushConsumer(opts ...Option) (*pushConsumer, error) {
 	for _, apply := range opts {
 		apply(&defaultOpts)
 	}
-	srvs, err := internal.NewNamesrv(defaultOpts.Resolver)
+	srvs, err := internal.NewNamesrv(defaultOpts.Resolver, defaultOpts.RemotingClientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "new Namesrv failed.")
 	}

--- a/internal/client.go
+++ b/internal/client.go
@@ -95,27 +95,29 @@ type InnerConsumer interface {
 
 func DefaultClientOptions() ClientOptions {
 	opts := ClientOptions{
-		InstanceName: "DEFAULT",
-		RetryTimes:   3,
-		ClientIP:     utils.LocalIP,
+		InstanceName:         "DEFAULT",
+		RetryTimes:           3,
+		ClientIP:             utils.LocalIP,
+		RemotingClientConfig: &remote.DefaultRemotingClientConfig,
 	}
 	return opts
 }
 
 type ClientOptions struct {
-	GroupName         string
-	NameServerAddrs   primitive.NamesrvAddr
-	Namesrv           Namesrvs
-	ClientIP          string
-	InstanceName      string
-	UnitMode          bool
-	UnitName          string
-	VIPChannelEnabled bool
-	RetryTimes        int
-	Interceptors      []primitive.Interceptor
-	Credentials       primitive.Credentials
-	Namespace         string
-	Resolver          primitive.NsResolver
+	GroupName            string
+	NameServerAddrs      primitive.NamesrvAddr
+	Namesrv              Namesrvs
+	ClientIP             string
+	InstanceName         string
+	UnitMode             bool
+	UnitName             string
+	VIPChannelEnabled    bool
+	RetryTimes           int
+	Interceptors         []primitive.Interceptor
+	Credentials          primitive.Credentials
+	Namespace            string
+	Resolver             primitive.NsResolver
+	RemotingClientConfig *remote.RemotingClientConfig
 }
 
 func (opt *ClientOptions) ChangeInstanceNameToPID() {
@@ -188,7 +190,7 @@ var clientMap sync.Map
 func GetOrNewRocketMQClient(option ClientOptions, callbackCh chan interface{}) RMQClient {
 	client := &rmqClient{
 		option:       option,
-		remoteClient: remote.NewRemotingClient(),
+		remoteClient: remote.NewRemotingClient(option.RemotingClientConfig),
 		done:         make(chan struct{}),
 	}
 	actual, loaded := clientMap.LoadOrStore(client.ClientID(), client)

--- a/internal/namesrv.go
+++ b/internal/namesrv.go
@@ -108,7 +108,7 @@ func GetNamesrv(clientId string) (*namesrvs, error) {
 
 // NewNamesrv init Namesrv from namesrv addr string.
 // addr primitive.NamesrvAddr
-func NewNamesrv(resolver primitive.NsResolver) (*namesrvs, error) {
+func NewNamesrv(resolver primitive.NsResolver, config *remote.RemotingClientConfig) (*namesrvs, error) {
 	addr := resolver.Resolve()
 	if len(addr) == 0 {
 		return nil, errors.New("no name server addr found with resolver: " + resolver.Description())
@@ -117,7 +117,7 @@ func NewNamesrv(resolver primitive.NsResolver) (*namesrvs, error) {
 	if err := primitive.NamesrvAddr(addr).Check(); err != nil {
 		return nil, err
 	}
-	nameSrvClient := remote.NewRemotingClient()
+	nameSrvClient := remote.NewRemotingClient(config)
 	return &namesrvs{
 		srvs:             addr,
 		lock:             new(sync.Mutex),

--- a/internal/namesrv_test.go
+++ b/internal/namesrv_test.go
@@ -36,7 +36,7 @@ import (
 // TestSelector test roundrobin selector in namesrv
 func TestSelector(t *testing.T) {
 	srvs := []string{"127.0.0.1:9876", "127.0.0.1:9879", "12.24.123.243:10911", "12.24.123.243:10915"}
-	namesrv, err := NewNamesrv(primitive.NewPassthroughResolver(srvs))
+	namesrv, err := NewNamesrv(primitive.NewPassthroughResolver(srvs), nil)
 	assert.Nil(t, err)
 
 	assert.Equal(t, srvs[0], namesrv.getNameServerAddress())

--- a/internal/remote/remote_client.go
+++ b/internal/remote/remote_client.go
@@ -293,6 +293,10 @@ func (c *remotingClient) doRequest(conn *tcpConnWrapper, request *RemotingComman
 
 	err := conn.Conn.SetWriteDeadline(time.Now().Add(120 * time.Second))
 	if err != nil {
+		rlog.Error("conn error, close connection", map[string]interface{}{
+			rlog.LogKeyUnderlayError: err,
+		})
+
 		c.closeConnection(conn)
 		conn.destroy()
 		return err
@@ -300,6 +304,10 @@ func (c *remotingClient) doRequest(conn *tcpConnWrapper, request *RemotingComman
 
 	err = request.WriteTo(conn)
 	if err != nil {
+		rlog.Error("conn error, close connection", map[string]interface{}{
+			rlog.LogKeyUnderlayError: err,
+		})
+
 		c.closeConnection(conn)
 		conn.destroy()
 		return err

--- a/internal/remote/remote_client_test.go
+++ b/internal/remote/remote_client_test.go
@@ -116,7 +116,7 @@ func TestCreateScanner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to encode RemotingCommand. %s", err)
 	}
-	client := NewRemotingClient()
+	client := NewRemotingClient(nil)
 	reader := bytes.NewReader(content)
 	scanner := client.createScanner(reader)
 	for scanner.Scan() {
@@ -151,7 +151,7 @@ func TestInvokeSync(t *testing.T) {
 	serverSendRemotingCommand.Flag = ResponseType
 	var wg sync.WaitGroup
 	wg.Add(1)
-	client := NewRemotingClient()
+	client := NewRemotingClient(nil)
 
 	var clientSend sync.WaitGroup // blocking client send message until the server listen success.
 	clientSend.Add(1)
@@ -216,7 +216,7 @@ func TestInvokeAsync(t *testing.T) {
 	var wg sync.WaitGroup
 	cnt := 50
 	wg.Add(cnt)
-	client := NewRemotingClient()
+	client := NewRemotingClient(nil)
 	for i := 0; i < cnt; i++ {
 		go func(index int) {
 			time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
@@ -282,7 +282,7 @@ func TestInvokeAsyncTimeout(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	client := NewRemotingClient()
+	client := NewRemotingClient(nil)
 
 	var clientSend sync.WaitGroup // blocking client send message until the server listen success.
 	clientSend.Add(1)
@@ -329,7 +329,7 @@ func TestInvokeOneWay(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	client := NewRemotingClient()
+	client := NewRemotingClient(nil)
 
 	var clientSend sync.WaitGroup // blocking client send message until the server listen success.
 	clientSend.Add(1)

--- a/internal/remote/tcp_conn.go
+++ b/internal/remote/tcp_conn.go
@@ -32,9 +32,11 @@ type tcpConnWrapper struct {
 	closed atomic.Bool
 }
 
-func initConn(ctx context.Context, addr string) (*tcpConnWrapper, error) {
+func initConn(ctx context.Context, addr string, config *RemotingClientConfig) (*tcpConnWrapper, error) {
 	var d net.Dialer
-	d.KeepAlive = time.Second * 120
+
+	d.KeepAlive = config.KeepAliveDuration
+	d.Deadline = time.Now().Add(config.ConnectionTimeout)
 
 	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {

--- a/internal/remote/tcp_conn.go
+++ b/internal/remote/tcp_conn.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"time"
 
 	"go.uber.org/atomic"
 )
@@ -33,6 +34,8 @@ type tcpConnWrapper struct {
 
 func initConn(ctx context.Context, addr string) (*tcpConnWrapper, error) {
 	var d net.Dialer
+	d.KeepAlive = time.Second * 120
+
 	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, err

--- a/internal/route_test.go
+++ b/internal/route_test.go
@@ -42,7 +42,7 @@ func TestQueryTopicRouteInfoFromServer(t *testing.T) {
 		addr, err := primitive.NewNamesrvAddr("1.1.1.1:8880", "1.1.1.2:8880", "1.1.1.3:8880")
 		assert.Nil(t, err)
 
-		namesrv, err := NewNamesrv(primitive.NewPassthroughResolver(addr))
+		namesrv, err := NewNamesrv(primitive.NewPassthroughResolver(addr), nil)
 		assert.Nil(t, err)
 		namesrv.nameSrvClient = remotingCli
 

--- a/internal/trace.go
+++ b/internal/trace.go
@@ -256,9 +256,9 @@ func NewTraceDispatcher(traceCfg *primitive.TraceConfig) *traceDispatcher {
 	var srvs *namesrvs
 	var err error
 	if len(traceCfg.NamesrvAddrs) > 0 {
-		srvs, err = NewNamesrv(primitive.NewPassthroughResolver(traceCfg.NamesrvAddrs))
+		srvs, err = NewNamesrv(primitive.NewPassthroughResolver(traceCfg.NamesrvAddrs), nil)
 	} else {
-		srvs, err = NewNamesrv(traceCfg.Resolver)
+		srvs, err = NewNamesrv(traceCfg.Resolver, nil)
 	}
 
 	if err != nil {

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -52,7 +52,7 @@ func NewDefaultProducer(opts ...Option) (*defaultProducer, error) {
 	for _, apply := range opts {
 		apply(&defaultOpts)
 	}
-	srvs, err := internal.NewNamesrv(defaultOpts.Resolver)
+	srvs, err := internal.NewNamesrv(defaultOpts.Resolver, defaultOpts.RemotingClientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "new Namesrv failed.")
 	}


### PR DESCRIPTION
fix #817

1. add tcp conn write and read deadline to avoid long time block socket ops when remote endpoint crash.

2. enable tcp keep alive.

3. remove request from responseTable when InvokeAsync.

4. doRequest close socket connection with destory call.