### PR TITLE
[ISSUE #832] Client may submit wrong offset when network instability

### DIFF
--- a/consumer/mock_offset_store.go
+++ b/consumer/mock_offset_store.go
@@ -28,67 +28,90 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
-// MockOffsetStore is a mock of OffsetStore interface
+// MockOffsetStore is a mock of OffsetStore interface.
 type MockOffsetStore struct {
 	ctrl     *gomock.Controller
 	recorder *MockOffsetStoreMockRecorder
 }
 
-// MockOffsetStoreMockRecorder is the mock recorder for MockOffsetStore
+// MockOffsetStoreMockRecorder is the mock recorder for MockOffsetStore.
 type MockOffsetStoreMockRecorder struct {
 	mock *MockOffsetStore
 }
 
-// NewMockOffsetStore creates a new mock instance
+// NewMockOffsetStore creates a new mock instance.
 func NewMockOffsetStore(ctrl *gomock.Controller) *MockOffsetStore {
 	mock := &MockOffsetStore{ctrl: ctrl}
 	mock.recorder = &MockOffsetStoreMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockOffsetStore) EXPECT() *MockOffsetStoreMockRecorder {
 	return m.recorder
 }
 
-// persist mocks base method
+// persist mocks base method.
 func (m *MockOffsetStore) persist(mqs []*primitive.MessageQueue) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "persist", mqs)
 }
 
-// persist indicates an expected call of persist
+// persist indicates an expected call of persist.
 func (mr *MockOffsetStoreMockRecorder) persist(mqs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "persist", reflect.TypeOf((*MockOffsetStore)(nil).persist), mqs)
 }
 
-// remove mocks base method
-func (m *MockOffsetStore) remove(mq *primitive.MessageQueue) {
-	m.ctrl.Call(m, "remove", mq)
-}
-
-// remove indicates an expected call of remove
-func (mr *MockOffsetStoreMockRecorder) remove(mq interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "remove", reflect.TypeOf((*MockOffsetStore)(nil).remove), mq)
-}
-
-// read mocks base method
+// read mocks base method.
 func (m *MockOffsetStore) read(mq *primitive.MessageQueue, t readType) int64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "read", mq, t)
 	ret0, _ := ret[0].(int64)
 	return ret0
 }
 
-// read indicates an expected call of read
+// read indicates an expected call of read.
 func (mr *MockOffsetStoreMockRecorder) read(mq, t interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "read", reflect.TypeOf((*MockOffsetStore)(nil).read), mq, t)
 }
 
-// update mocks base method
+// readWithException mocks base method.
+func (m *MockOffsetStore) readWithException(mq *primitive.MessageQueue, t readType) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "readWithException", mq, t)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// readWithException indicates an expected call of readWithException.
+func (mr *MockOffsetStoreMockRecorder) readWithException(mq, t interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "readWithException", reflect.TypeOf((*MockOffsetStore)(nil).readWithException), mq, t)
+}
+
+// remove mocks base method.
+func (m *MockOffsetStore) remove(mq *primitive.MessageQueue) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "remove", mq)
+}
+
+// remove indicates an expected call of remove.
+func (mr *MockOffsetStoreMockRecorder) remove(mq interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "remove", reflect.TypeOf((*MockOffsetStore)(nil).remove), mq)
+}
+
+// update mocks base method.
 func (m *MockOffsetStore) update(mq *primitive.MessageQueue, offset int64, increaseOnly bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "update", mq, offset, increaseOnly)
 }
 
-// update indicates an expected call of update
+// update indicates an expected call of update.
 func (mr *MockOffsetStoreMockRecorder) update(mq, offset, increaseOnly interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "update", reflect.TypeOf((*MockOffsetStore)(nil).update), mq, offset, increaseOnly)
 }

--- a/consumer/offset_store_test.go
+++ b/consumer/offset_store_test.go
@@ -98,7 +98,7 @@ func TestLocalFileOffsetStore(t *testing.T) {
 				}
 				for _, value := range cases {
 					localStore.update(value.queue, value.setOffset, false)
-					offset := localStore.read(value.queue, _ReadFromMemory)
+					offset, _ := localStore.readWithException(value.queue, _ReadFromMemory)
 					So(offset, ShouldEqual, value.expectedOffset)
 				}
 			})
@@ -119,7 +119,7 @@ func TestLocalFileOffsetStore(t *testing.T) {
 				}
 				for _, value := range cases {
 					localStore.update(value.queue, value.setOffset, true)
-					offset := localStore.read(value.queue, _ReadFromMemory)
+					offset, _ := localStore.readWithException(value.queue, _ReadFromMemory)
 					So(offset, ShouldEqual, value.expectedOffset)
 				}
 			})
@@ -127,16 +127,16 @@ func TestLocalFileOffsetStore(t *testing.T) {
 
 		Convey("test persist", func() {
 			localStore.update(mq, 1, false)
-			offset := localStore.read(mq, _ReadFromMemory)
+			offset, _ := localStore.readWithException(mq, _ReadFromMemory)
 			So(offset, ShouldEqual, 1)
 
 			queues := []*primitive.MessageQueue{mq}
 			localStore.persist(queues)
-			offset = localStore.read(mq, _ReadFromStore)
+			offset, _ = localStore.readWithException(mq, _ReadFromStore)
 			So(offset, ShouldEqual, 1)
 
 			localStore.(*localFileOffsetStore).OffsetTable.Delete(MessageQueueKey(*mq))
-			offset = localStore.read(mq, _ReadMemoryThenStore)
+			offset, _ = localStore.readWithException(mq, _ReadMemoryThenStore)
 			So(offset, ShouldEqual, 1)
 		})
 	})
@@ -178,7 +178,7 @@ func TestRemoteBrokerOffsetStore(t *testing.T) {
 				}
 				for _, value := range cases {
 					remoteStore.update(value.queue, value.setOffset, false)
-					offset := remoteStore.read(value.queue, _ReadFromMemory)
+					offset, _ := remoteStore.readWithException(value.queue, _ReadFromMemory)
 					So(offset, ShouldEqual, value.expectedOffset)
 				}
 			})
@@ -199,7 +199,7 @@ func TestRemoteBrokerOffsetStore(t *testing.T) {
 				}
 				for _, value := range cases {
 					remoteStore.update(value.queue, value.setOffset, true)
-					offset := remoteStore.read(value.queue, _ReadFromMemory)
+					offset, _ := remoteStore.readWithException(value.queue, _ReadFromMemory)
 					So(offset, ShouldEqual, value.expectedOffset)
 				}
 			})
@@ -219,24 +219,24 @@ func TestRemoteBrokerOffsetStore(t *testing.T) {
 			rmqClient.EXPECT().InvokeSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(ret, nil).MaxTimes(2)
 
 			remoteStore.persist(queues)
-			offset := remoteStore.read(mq, _ReadFromStore)
+			offset, _ := remoteStore.readWithException(mq, _ReadFromStore)
 			So(offset, ShouldEqual, 1)
 
 			remoteStore.remove(mq)
-			offset = remoteStore.read(mq, _ReadFromMemory)
+			offset, _ = remoteStore.readWithException(mq, _ReadFromMemory)
 			So(offset, ShouldEqual, -1)
-			offset = remoteStore.read(mq, _ReadMemoryThenStore)
+			offset, _ = remoteStore.readWithException(mq, _ReadMemoryThenStore)
 			So(offset, ShouldEqual, 1)
 
 		})
 
 		Convey("test remove", func() {
 			remoteStore.update(mq, 1, false)
-			offset := remoteStore.read(mq, _ReadFromMemory)
+			offset, _ := remoteStore.readWithException(mq, _ReadFromMemory)
 			So(offset, ShouldEqual, 1)
 
 			remoteStore.remove(mq)
-			offset = remoteStore.read(mq, _ReadFromMemory)
+			offset, _ = remoteStore.readWithException(mq, _ReadFromMemory)
 			So(offset, ShouldEqual, -1)
 		})
 	})

--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -20,9 +20,10 @@ package consumer
 import (
 	"context"
 	"fmt"
-	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 	"sync"
 	"sync/atomic"
+
+	errors2 "github.com/apache/rocketmq-client-go/v2/errors"
 
 	"github.com/pkg/errors"
 
@@ -219,7 +220,8 @@ func (c *defaultPullConsumer) makeSureStateOK() error {
 }
 
 func (c *defaultPullConsumer) nextOffsetOf(queue *primitive.MessageQueue) int64 {
-	return c.computePullFromWhere(queue)
+	result, _ := c.computePullFromWhereWithException(queue)
+	return result
 }
 
 // PullFrom pull messages of queue from the offset to offset + numbers


### PR DESCRIPTION
## What is the purpose of the change
fix #832 
To expose the error thrown when client failed to get offset from broker

## Brief changelog

- add `readWithException` to `OffsetStore` and deprecate `read`
- add `computePullFromWhereWithException` to `defaultConsumer` and deprecate `computePullFromWhere`
- test files to use new methods

## Verifying this change

- add a 60s sleeping time to broker's `ConsumerOffsetManager.queryOffset` function, start this broker
- start consumer and check if the consumer's offset is set to minLogicOffset

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
