### PR TITLE
[ISSUE #840]consumer consume include tag according to accumulation

### DIFF
--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -692,7 +692,7 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 
 		sd := v.(*internal.SubscriptionData)
 		classFilter := sd.ClassFilterMode
-		if pc.option.PostSubscriptionWhenPull && classFilter {
+		if pc.option.PostSubscriptionWhenPull && !classFilter {
 			subExpression = sd.SubString
 		}
 
@@ -706,7 +706,7 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 			MaxMsgNums:           pc.option.PullBatchSize,
 			SysFlag:              sysFlag,
 			CommitOffset:         commitOffsetValue,
-			SubExpression:        _SubAll,
+			SubExpression:        subExpression,
 			ExpressionType:       string(TAG),
 			SuspendTimeoutMillis: 20 * time.Second,
 		}


### PR DESCRIPTION
## What is the purpose of the change

fix NOT_CONSUME_YET status message problem

## Brief changelog

when consumer include tag info, our's mq service have many NOT_CONSUME_YET status message

## Verifying this change


