### PR TITLE
[feat] incr instanceCount in once and fmt codes

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -274,9 +274,7 @@ func (dc *defaultConsumer) start() error {
 		retryTopic := internal.GetRetryTopic(dc.consumerGroup)
 		sub := buildSubscriptionData(retryTopic, MessageSelector{TAG, _SubAll})
 		dc.subscriptionDataTable.Store(retryTopic, sub)
-	}
 
-	if dc.model == Clustering {
 		dc.option.ChangeInstanceNameToPID()
 		dc.storage = NewRemoteOffsetStore(dc.consumerGroup, dc.client, dc.client.GetNameSrv())
 	} else {

--- a/internal/client.go
+++ b/internal/client.go
@@ -384,8 +384,10 @@ func GetOrNewRocketMQClient(option ClientOptions, callbackCh chan interface{}) R
 func (c *rmqClient) Start() {
 	//ctx, cancel := context.WithCancel(context.Background())
 	//c.cancel = cancel
-	atomic.AddInt32(&c.instanceCount, 1)
 	c.once.Do(func() {
+
+		atomic.AddInt32(&c.instanceCount, 1)
+
 		if !c.option.Credentials.IsEmpty() {
 			c.remoteClient.RegisterInterceptor(remote.ACLInterceptor(c.option.Credentials))
 		}


### PR DESCRIPTION
## What is the purpose of the change

i think we should incr instanceCount once, if we Start  a consumer more than one times, instanceCount will increase one times, in the case, rmqClient.ShutDown will never work

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
