### PR TITLE
(feat): add user defined topic dimension consumer limiter

### DIFF
--- a/consumer/limiter.go
+++ b/consumer/limiter.go
@@ -1,0 +1,3 @@
+package consumer
+
+type Limiter func(topic string)

--- a/consumer/option.go
+++ b/consumer/option.go
@@ -111,6 +111,8 @@ type consumerOptions struct {
 	ConsumeGoroutineNums int
 
 	filterMessageHooks []hooks.FilterMessageHook
+
+	Limiter Limiter
 }
 
 func defaultPushConsumerOptions() consumerOptions {
@@ -342,5 +344,11 @@ func WithConsumeGoroutineNums(nums int) Option {
 func WithFilterMessageHook(hooks []hooks.FilterMessageHook) Option {
 	return func(opts *consumerOptions) {
 		opts.filterMessageHooks = hooks
+	}
+}
+
+func WithLimiter(limiter Limiter) Option {
+	return func(opts *consumerOptions) {
+		opts.Limiter = limiter
 	}
 }

--- a/internal/utils/namespace.go
+++ b/internal/utils/namespace.go
@@ -3,6 +3,8 @@ package utils
 import "strings"
 
 const namespaceSeparator = "%"
+const retryPrefix = "%RETRY%"
+const dlqPrefix = "%DLQ%"
 
 func WrapNamespace(namespace, resourceWithOutNamespace string) string {
 	if IsEmpty(namespace) || IsEmpty(resourceWithOutNamespace) {
@@ -21,4 +23,23 @@ func isAlreadyWithNamespace(resource, namespace string) bool {
 		return false
 	}
 	return strings.Contains(resource, namespace+namespaceSeparator)
+}
+
+func WithoutNamespace(resource string) string {
+	if len(resource) == 0 {
+		return resource
+	}
+	resourceWithoutNamespace := ""
+	if strings.HasPrefix(resource, retryPrefix) {
+		resourceWithoutNamespace += retryPrefix
+	} else if strings.HasPrefix(resource, dlqPrefix) {
+		resourceWithoutNamespace += dlqPrefix
+	}
+	index := strings.LastIndex(resource, namespaceSeparator)
+	if index > 0 {
+		resourceWithoutNamespace += resource[index+1:]
+	} else {
+		resourceWithoutNamespace = resource
+	}
+	return resourceWithoutNamespace
 }


### PR DESCRIPTION
## What is the purpose of the change

Add user defined consume rate limiter which is topic dimension. The user could use self defined Limiter 'block' consume to controller topic consume rate based on  TPS / Concurrent / Load or any other condition.

## Brief changelog
- add consumer Limiter func definition.
- add Limiter to push_consumer#consumeMessageCurrently 

https://github.com/apache/rocketmq-client-go/issues/896