### PR TITLE
[ISSUE #897] fix consumer doesn't consume message because of blocked on Lock

### DIFF
--- a/consumer/process_queue.go
+++ b/consumer/process_queue.go
@@ -104,6 +104,7 @@ func (pq *processQueue) putMessage(messages ...*primitive.MessageExt) {
 	if !pq.order {
 		select {
 		case <-pq.closeChan:
+			pq.mutex.Unlock()
 			return
 		case pq.msgCh <- messages:
 		}


### PR DESCRIPTION
## What is the purpose of the change

fix consumer doesn't consume message because of blocked on Lock in so…
#897 