### PR TITLE
[ISSUE #916] Modify producer api to increase flexibility

### DIFF
--- a/api.go
+++ b/api.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/apache/rocketmq-client-go/v2/consumer"
-	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/producer"
 )
@@ -35,7 +34,7 @@ type Producer interface {
 		msg ...*primitive.Message) error
 	SendOneWay(ctx context.Context, mq ...*primitive.Message) error
 	Request(ctx context.Context, ttl time.Duration, msg *primitive.Message) (*primitive.Message, error)
-	RequestAsync(ctx context.Context, ttl time.Duration, callback internal.RequestCallback, msg *primitive.Message) error
+	RequestAsync(ctx context.Context, ttl time.Duration, callback func(ctx context.Context, msg *primitive.Message, err error), msg *primitive.Message) error
 }
 
 func NewProducer(opts ...producer.Option) (Producer, error) {

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -222,7 +222,8 @@ func (p *defaultProducer) Request(ctx context.Context, timeout time.Duration, ms
 }
 
 // RequestAsync  Async Send messages to consumer
-func (p *defaultProducer) RequestAsync(ctx context.Context, timeout time.Duration, callback internal.RequestCallback, msg *primitive.Message) error {
+func (p *defaultProducer) RequestAsync(ctx context.Context, timeout time.Duration,
+	callback func(ctx context.Context, msg *primitive.Message, err error), msg *primitive.Message) error {
 	if err := p.checkMsg(msg); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What is the purpose of the change

#916 

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/63457588/189415479-00db5303-ac96-4af5-8642-4ff8e1dab0bd.png">

```RequestAsync``` has an argument ```callback``` which is an internal function type.

Maybes it's better to define an API function without importing an internal definition. 

For example:
1. When I tried to implement a mock producer to do unit testing of my business logic, it was almost impossible.
2. When I tried to implement a wrapper producer which integrated some custom logic, it was also very hard to do.

## Brief changelog

change callback type to raw function definition.


