### PR TITLE
fix some errors reported by go vet

### DIFF
--- a/consumer/lock.go
+++ b/consumer/lock.go
@@ -31,7 +31,7 @@ func newQueueLock() *QueueLock {
 	return &QueueLock{}
 }
 
-func (ql QueueLock) fetchLock(queue primitive.MessageQueue) sync.Locker {
+func (ql *QueueLock) fetchLock(queue primitive.MessageQueue) sync.Locker {
 	v, _ := ql.lockTable.LoadOrStore(queue, new(sync.Mutex))
 	return v.(*sync.Mutex)
 }

--- a/internal/remote/remote_client.go
+++ b/internal/remote/remote_client.go
@@ -149,7 +149,7 @@ func (c *remotingClient) InvokeOneWay(ctx context.Context, addr string, request 
 }
 
 func (c *remotingClient) connect(ctx context.Context, addr string) (*tcpConnWrapper, error) {
-	//it needs additional locker.
+	// it needs additional locker.
 	c.connectionLocker.Lock()
 	defer c.connectionLocker.Unlock()
 	conn, ok := c.connectionTable.Load(addr)
@@ -323,7 +323,7 @@ func (c *remotingClient) doRequest(conn *tcpConnWrapper, request *RemotingComman
 		return err
 	}
 
-	err = request.WriteTo(conn)
+	_, err = request.WriteTo(conn)
 	if err != nil {
 		rlog.Error("conn error, close connection", map[string]interface{}{
 			rlog.LogKeyUnderlayError: err,

--- a/internal/remote/remote_client_test.go
+++ b/internal/remote/remote_client_test.go
@@ -19,13 +19,15 @@ package remote
 import (
 	"bytes"
 	"context"
-	"github.com/apache/rocketmq-client-go/v2/errors"
+	"log"
 	"math/rand"
 	"net"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/apache/rocketmq-client-go/v2/errors"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -161,7 +163,7 @@ func TestInvokeSync(t *testing.T) {
 		receiveCommand, err := client.InvokeSync(context.Background(), addr,
 			clientSendRemtingCommand)
 		if err != nil {
-			t.Fatalf("failed to invoke synchronous. %s", err)
+			log.Fatalf("failed to invoke synchronous. %v", err)
 		} else {
 			assert.Equal(t, len(receiveCommand.ExtFields), 0)
 			assert.Equal(t, len(serverSendRemotingCommand.ExtFields), 0)
@@ -337,7 +339,7 @@ func TestInvokeOneWay(t *testing.T) {
 		clientSend.Wait()
 		err := client.InvokeOneWay(context.Background(), addr, clientSendRemtingCommand)
 		if err != nil {
-			t.Fatalf("failed to invoke synchronous. %s", err)
+			log.Fatalf("failed to invoke synchronous. %v", err)
 		}
 		wg.Done()
 	}()

--- a/internal/trace.go
+++ b/internal/trace.go
@@ -103,7 +103,7 @@ func (ctx *TraceContext) marshal2Bean() *TraceTransferBean {
 		} else {
 			buffer.WriteString(bean.Topic)
 		}
-		//buffer.WriteString(bean.Topic)
+		// buffer.WriteString(bean.Topic)
 		buffer.WriteRune(contentSplitter)
 		buffer.WriteString(bean.MsgId)
 		buffer.WriteRune(contentSplitter)
@@ -243,7 +243,6 @@ type traceDispatcher struct {
 
 func NewTraceDispatcher(traceCfg *primitive.TraceConfig) *traceDispatcher {
 	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
 
 	t := traceCfg.TraceTopic
 	if len(t) == 0 {
@@ -285,6 +284,8 @@ func NewTraceDispatcher(traceCfg *primitive.TraceConfig) *traceDispatcher {
 		return nil
 	}
 	cliOp.Namesrv = cli.GetNameSrv()
+
+	ctx, cancel := context.WithCancel(ctx)
 	return &traceDispatcher{
 		ctx:    ctx,
 		cancel: cancel,

--- a/primitive/ctx.go
+++ b/primitive/ctx.go
@@ -153,7 +153,7 @@ func GetConcurrentlyCtx(ctx context.Context) (*ConsumeConcurrentlyContext, bool)
 
 type ProducerCtx struct {
 	ProducerGroup     string
-	Message           Message
+	Message           *Message
 	MQ                MessageQueue
 	BrokerAddr        string
 	BornHost          string

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -277,7 +277,7 @@ func (p *defaultProducer) SendSync(ctx context.Context, msgs ...*primitive.Messa
 			ProducerGroup:     p.group,
 			CommunicationMode: primitive.SendSync,
 			BornHost:          utils.LocalIP,
-			Message:           *msg,
+			Message:           msg,
 			SendResult:        resp,
 		}
 		ctx = primitive.WithProducerCtx(ctx, producerCtx)


### PR DESCRIPTION
## What is the purpose of the change

fix some errors reported by go vet

## Brief changelog

go vet ./...
```
# github.com/apache/rocketmq-client-go/v2/producer
producer/producer.go:280:23: literal copies lock value from *msg: github.com/apache/rocketmq-client-go/v2/primitive.Message contains sync.RWMutex
# github.com/apache/rocketmq-client-go/v2/internal/remote
internal/remote/codec.go:136:33: method WriteTo(w io.Writer) error should have signature WriteTo(io.Writer) (int64, error)
internal/remote/remote_client_test.go:164:4: call to (*T).Fatalf from a non-test goroutine
internal/remote/remote_client_test.go:340:4: call to (*T).Fatalf from a non-test goroutine
# github.com/apache/rocketmq-client-go/v2/consumer
consumer/lock.go:34:10: fetchLock passes lock by value: github.com/apache/rocketmq-client-go/v2/consumer.QueueLock contains sync.Map contains sync.Mutex
# github.com/apache/rocketmq-client-go/v2/internal
internal/trace.go:246:2: the cancel function is not used on all paths (possible context leak)
internal/trace.go:285:3: this return statement may be reached without using the cancel var defined on line 246
```
