### PR TITLE
trace config add InstanceName field

### DIFF
--- a/internal/trace.go
+++ b/internal/trace.go
@@ -277,6 +277,9 @@ func NewTraceDispatcher(traceCfg *primitive.TraceConfig) *traceDispatcher {
 	cliOp.GroupName = traceCfg.GroupName
 	cliOp.NameServerAddrs = traceCfg.NamesrvAddrs
 	cliOp.InstanceName = "INNER_TRACE_CLIENT_DEFAULT"
+	if traceCfg.InstanceName != "" {
+		cliOp.InstanceName = traceCfg.InstanceName
+	}
 	cliOp.RetryTimes = 0
 	cliOp.Namesrv = srvs
 	cliOp.Credentials = traceCfg.Credentials

--- a/primitive/trace.go
+++ b/primitive/trace.go
@@ -21,6 +21,7 @@ package primitive
 type TraceConfig struct {
 	TraceTopic   string
 	GroupName    string
+	InstanceName string
 	Access       AccessChannel
 	NamesrvAddrs []string
 	Resolver     NsResolver


### PR DESCRIPTION
## What is the purpose of the change

One service connect more than one instance RocketMQ，all with trace，they should different InstanceName

## Brief changelog

trace config add InstanceName field

## Verifying this change

One service connect more than one instance RocketMQ，

