### PR TITLE
chore: format error log printing

### DIFF
--- a/benchmark/producer.go
+++ b/benchmark/producer.go
@@ -20,16 +20,17 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/apache/rocketmq-client-go/v2"
-	"github.com/apache/rocketmq-client-go/v2/primitive"
-	"github.com/apache/rocketmq-client-go/v2/producer"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"os"
 	"os/signal"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/apache/rocketmq-client-go/v2"
+	"github.com/apache/rocketmq-client-go/v2/primitive"
+	"github.com/apache/rocketmq-client-go/v2/producer"
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 type statiBenchmarkProducerSnapshot struct {
@@ -135,7 +136,7 @@ func (bp *producerBenchmark) produceMsg(stati *statiBenchmarkProducerSnapshot, e
 
 	if err != nil {
 		rlog.Error("New Producer Error", map[string]interface{}{
-			rlog.LogKeyUnderlayError: err.Error(),
+			rlog.LogKeyUnderlayError: err,
 		})
 		return
 	}
@@ -159,7 +160,7 @@ AGAIN:
 
 	if err != nil {
 		rlog.Error("Send Message Error", map[string]interface{}{
-			rlog.LogKeyUnderlayError: err.Error(),
+			rlog.LogKeyUnderlayError: err,
 		})
 		goto AGAIN
 	}
@@ -179,9 +180,9 @@ AGAIN:
 		goto AGAIN
 	}
 	rlog.Error("Send Message Error", map[string]interface{}{
-		"topic":                  topic,
+		rlog.LogKeyTopic:         topic,
 		"tag":                    tag,
-		rlog.LogKeyUnderlayError: err.Error(),
+		rlog.LogKeyUnderlayError: err,
 	})
 	goto AGAIN
 }

--- a/benchmark/stable.go
+++ b/benchmark/stable.go
@@ -19,12 +19,13 @@ package main
 
 import (
 	"flag"
-	"github.com/apache/rocketmq-client-go/v2/errors"
-	"github.com/apache/rocketmq-client-go/v2/rlog"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/apache/rocketmq-client-go/v2/errors"
+	"github.com/apache/rocketmq-client-go/v2/rlog"
 )
 
 type stableTest struct {
@@ -100,7 +101,7 @@ type stableTestProducer struct {
 	*stableTest
 	bodySize int
 
-	//p rocketmq.Producer
+	// p rocketmq.Producer
 }
 
 func (stp *stableTestProducer) buildFlags(name string) {
@@ -138,45 +139,45 @@ func (stp *stableTestProducer) run(args []string) {
 	err = stp.checkFlag()
 	if err != nil {
 		rlog.Error("Check Flag Error", map[string]interface{}{
-			rlog.LogKeyUnderlayError: err.Error(),
+			rlog.LogKeyUnderlayError: err,
 		})
 		stp.usage()
 		return
 	}
 
-	//p, err := rocketmq.NewProducer(&rocketmq.ProducerConfig{
+	// p, err := rocketmq.NewProducer(&rocketmq.ProducerConfig{
 	//	ClientConfig: rocketmq.ClientConfig{GroupID: stp.groupID, NameServer: stp.nameSrv},
-	//})
-	//if err != nil {
+	// })
+	// if err != nil {
 	//	fmt.Printf("new consumer error:%s\n", err)
 	//	return
-	//}
+	// }
 	//
-	//err = p.Start()
-	//if err != nil {
+	// err = p.Start()
+	// if err != nil {
 	//	fmt.Printf("start consumer error:%s\n", err)
 	//	return
-	//}
-	//defer p.Shutdown()
+	// }
+	// defer p.Shutdown()
 	//
-	//stp.p = p
+	// stp.p = p
 	stp.stableTest.run()
 }
 
 func (stp *stableTestProducer) sendMessage() {
-	//r, err := stp.p.SendMessageSync(&rocketmq.Message{Topic: stp.topic, Body: buildMsg(stp.bodySize)})
-	//if err == nil {
+	// r, err := stp.p.SendMessageSync(&rocketmq.Message{Topic: stp.topic, Body: buildMsg(stp.bodySize)})
+	// if err == nil {
 	//	fmt.Printf("send result:%+v\n", r)
 	//	return
-	//}
-	//fmt.Printf("send message error:%s", err)
+	// }
+	// fmt.Printf("send message error:%s", err)
 }
 
 type stableTestConsumer struct {
 	*stableTest
 	expression string
 
-	//c       rocketmq.PullConsumer
+	// c       rocketmq.PullConsumer
 	offsets map[int]int64
 }
 
@@ -206,7 +207,7 @@ func (stc *stableTestConsumer) run(args []string) {
 	if err != nil {
 		rlog.Error("Parse Args Error", map[string]interface{}{
 			"args":                   args,
-			rlog.LogKeyUnderlayError: err.Error(),
+			rlog.LogKeyUnderlayError: err,
 		})
 		stc.usage()
 		return
@@ -215,52 +216,52 @@ func (stc *stableTestConsumer) run(args []string) {
 	err = stc.checkFlag()
 	if err != nil {
 		rlog.Error("Check Flag Error", map[string]interface{}{
-			rlog.LogKeyUnderlayError: err.Error(),
+			rlog.LogKeyUnderlayError: err,
 		})
 		stc.usage()
 		return
 	}
 	//
-	//c, err := rocketmq.NewPullConsumer(&rocketmq.PullConsumerConfig{
+	// c, err := rocketmq.NewPullConsumer(&rocketmq.PullConsumerConfig{
 	//	ClientConfig: rocketmq.ClientConfig{GroupID: stc.groupID, NameServer: stc.nameSrv},
-	//})
-	//if err != nil {
+	// })
+	// if err != nil {
 	//	fmt.Printf("new pull consumer error:%s\n", err)
 	//	return
-	//}
+	// }
 	//
-	//err = c.Start()
-	//if err != nil {
+	// err = c.Start()
+	// if err != nil {
 	//	fmt.Printf("start consumer error:%s\n", err)
 	//	return
-	//}
-	//defer c.Shutdown()
+	// }
+	// defer c.Shutdown()
 	//
-	//stc.c = c
+	// stc.c = c
 	stc.stableTest.run()
 }
 
 func (stc *stableTestConsumer) pullMessage() {
-	//mqs := stc.c.FetchSubscriptionMessageQueues(stc.topic)
+	// mqs := stc.c.FetchSubscriptionMessageQueues(stc.topic)
 	//
-	//for _, mq := range mqs {
+	// for _, mq := range mqs {
 	//	offset := stc.offsets[mq.ID]
 	//	pr := stc.c.Pull(mq, stc.expression, offset, 32)
-	//fmt.Printf("pull from %s, offset:%d, count:%+v\n", mq.String(), offset, len(pr.Messages))
+	// fmt.Printf("pull from %s, offset:%d, count:%+v\n", mq.String(), offset, len(pr.Messages))
 	//
-	//switch pr.Status {
-	//case rocketmq.PullNoNewMsg:
+	// switch pr.Status {
+	// case rocketmq.PullNoNewMsg:
 	//	stc.offsets[mq.ID] = 0 // pull from the begin
-	//case rocketmq.PullFound:
+	// case rocketmq.PullFound:
 	//	fallthrough
-	//case rocketmq.PullNoMatchedMsg:
+	// case rocketmq.PullNoMatchedMsg:
 	//	fallthrough
-	//case rocketmq.PullOffsetIllegal:
+	// case rocketmq.PullOffsetIllegal:
 	//	stc.offsets[mq.ID] = pr.NextBeginOffset
-	//case rocketmq.PullBrokerTimeout:
+	// case rocketmq.PullBrokerTimeout:
 	//	fmt.Println("broker timeout occur")
-	//}
-	//}
+	// }
+	// }
 }
 
 func init() {

--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -148,7 +148,7 @@ func (pc *defaultPullConsumer) Start() error {
 		if err != nil {
 			rlog.Error("the consumer group option validate fail", map[string]interface{}{
 				rlog.LogKeyConsumerGroup: pc.consumerGroup,
-				rlog.LogKeyUnderlayError: err.Error(),
+				rlog.LogKeyUnderlayError: err,
 			})
 			err = errors.Wrap(err, "the consumer group option validate fail")
 			return
@@ -157,6 +157,7 @@ func (pc *defaultPullConsumer) Start() error {
 		if err != nil {
 			rlog.Error("defaultPullConsumer the consumer group has been created, specify another one", map[string]interface{}{
 				rlog.LogKeyConsumerGroup: pc.consumerGroup,
+				rlog.LogKeyUnderlayError: err,
 			})
 			err = errors2.ErrCreated
 			return
@@ -380,7 +381,7 @@ func (pc *defaultPullConsumer) getNextQueueOf(topic string) *primitive.MessageQu
 		if err != nil {
 			rlog.Error("get next mq error", map[string]interface{}{
 				rlog.LogKeyTopic:         topic,
-				rlog.LogKeyUnderlayError: err.Error(),
+				rlog.LogKeyUnderlayError: err,
 			})
 			return nil
 		}
@@ -583,7 +584,7 @@ func (pc *defaultPullConsumer) GetConsumerRunningInfo(stack bool) *internal.Cons
 		err := pprof.Lookup("goroutine").WriteTo(&buffer, 2)
 		if err != nil {
 			rlog.Error("error when get stack ", map[string]interface{}{
-				"error": err,
+				rlog.LogKeyUnderlayError: err,
 			})
 		} else {
 			info.JStack = buffer.String()

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -143,7 +143,7 @@ func (pc *pushConsumer) Start() error {
 		if err != nil {
 			rlog.Error("the consumer group option validate fail", map[string]interface{}{
 				rlog.LogKeyConsumerGroup: pc.consumerGroup,
-				rlog.LogKeyUnderlayError: err.Error(),
+				rlog.LogKeyUnderlayError: err,
 			})
 			err = errors.Wrap(err, "the consumer group option validate fail")
 			return
@@ -153,6 +153,7 @@ func (pc *pushConsumer) Start() error {
 		if err != nil {
 			rlog.Error("the consumer group has been created, specify another one", map[string]interface{}{
 				rlog.LogKeyConsumerGroup: pc.consumerGroup,
+				rlog.LogKeyUnderlayError: err,
 			})
 			err = errors2.ErrCreated
 			return
@@ -461,7 +462,7 @@ func (pc *pushConsumer) GetConsumerRunningInfo(stack bool) *internal.ConsumerRun
 		err := pprof.Lookup("goroutine").WriteTo(&buffer, 2)
 		if err != nil {
 			rlog.Error("error when get stack ", map[string]interface{}{
-				"error": err,
+				rlog.LogKeyUnderlayError: err,
 			})
 		} else {
 			info.JStack = buffer.String()
@@ -806,11 +807,11 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 			SuspendTimeoutMillis: 20 * time.Second,
 		}
 		//
-		//if data.ExpType == string(TAG) {
+		// if data.ExpType == string(TAG) {
 		//	pullRequest.SubVersion = 0
-		//} else {
+		// } else {
 		//	pullRequest.SubVersion = data.SubVersion
-		//}
+		// }
 
 		brokerResult := pc.defaultConsumer.tryFindBroker(request.mq)
 		if brokerResult == nil {
@@ -938,31 +939,31 @@ func (pc *pushConsumer) resume() {
 }
 
 func (pc *pushConsumer) ResetOffset(topic string, table map[primitive.MessageQueue]int64) {
-	//topic := cmd.ExtFields["topic"]
-	//group := cmd.ExtFields["group"]
-	//if topic == "" || group == "" {
+	// topic := cmd.ExtFields["topic"]
+	// group := cmd.ExtFields["group"]
+	// if topic == "" || group == "" {
 	//	rlog.Warning("received reset offset command from: %s, but missing params.", from)
 	//	return
-	//}
-	//t, err := strconv.ParseInt(cmd.ExtFields["timestamp"], 10, 64)
-	//if err != nil {
+	// }
+	// t, err := strconv.ParseInt(cmd.ExtFields["timestamp"], 10, 64)
+	// if err != nil {
 	//	rlog.Warning("received reset offset command from: %s, but parse time error: %s", err.Error())
 	//	return
-	//}
-	//rlog.Infof("invoke reset offset operation from broker. brokerAddr=%s, topic=%s, group=%s, timestamp=%v",
+	// }
+	// rlog.Infof("invoke reset offset operation from broker. brokerAddr=%s, topic=%s, group=%s, timestamp=%v",
 	//	from, topic, group, t)
 	//
-	//offsetTable := make(map[MessageQueue]int64, 0)
-	//err = json.Unmarshal(cmd.Body, &offsetTable)
-	//if err != nil {
+	// offsetTable := make(map[MessageQueue]int64, 0)
+	// err = json.Unmarshal(cmd.Body, &offsetTable)
+	// if err != nil {
 	//	rlog.Warning("received reset offset command from: %s, but parse offset table: %s", err.Error())
 	//	return
-	//}
-	//v, exist := c.consumerMap.Load(group)
-	//if !exist {
+	// }
+	// v, exist := c.consumerMap.Load(group)
+	// if !exist {
 	//	rlog.Infof("[reset-offset] consumer dose not exist. group=%s", group)
 	//	return
-	//}
+	// }
 	pc.suspend()
 	defer pc.resume()
 
@@ -1272,15 +1273,15 @@ func (pc *pushConsumer) consumeMessageOrderly(pq *processQueue, mq *primitive.Me
 			}
 
 			// just put consumeResult in consumerMessageCtx
-			//interval = time.Now().Sub(beginTime)
-			//consumeReult := SuccessReturn
-			//if interval > pc.option.ConsumeTimeout {
+			// interval = time.Now().Sub(beginTime)
+			// consumeReult := SuccessReturn
+			// if interval > pc.option.ConsumeTimeout {
 			//	consumeReult = TimeoutReturn
-			//} else if SuspendCurrentQueueAMoment == result {
+			// } else if SuspendCurrentQueueAMoment == result {
 			//	consumeReult = FailedReturn
-			//} else if ConsumeSuccess == result {
+			// } else if ConsumeSuccess == result {
 			//	consumeReult = SuccessReturn
-			//}
+			// }
 
 			// process result
 			commitOffset := int64(-1)

--- a/internal/model.go
+++ b/internal/model.go
@@ -21,15 +21,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/tidwall/gjson"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/tidwall/gjson"
+
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/apache/rocketmq-client-go/v2/internal/utils"
 	"github.com/apache/rocketmq-client-go/v2/primitive"
 	"github.com/apache/rocketmq-client-go/v2/rlog"
-	jsoniter "github.com/json-iterator/go"
 )
 
 type FindBrokerResult struct {
@@ -426,7 +428,8 @@ func parseFastJsonFormat(body []byte) map[primitive.MessageQueue]int64 {
 
 		if err != nil {
 			rlog.Error("parse reset offset table json get nothing in body", map[string]interface{}{
-				"origin json": jsonStr,
+				"origin json":            jsonStr,
+				rlog.LogKeyUnderlayError: err,
 			})
 		}
 

--- a/internal/utils/errors.go
+++ b/internal/utils/errors.go
@@ -24,7 +24,7 @@ import (
 func CheckError(action string, err error) {
 	if err != nil {
 		rlog.Error(action, map[string]interface{}{
-			rlog.LogKeyUnderlayError: err.Error(),
+			rlog.LogKeyUnderlayError: err,
 		})
 	}
 }

--- a/primitive/nsresolver.go
+++ b/primitive/nsresolver.go
@@ -6,7 +6,7 @@ The ASF licenses this file to You under the Apache License, Version 2.0
 (the "License"); you may not use this file except in compliance with
 the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -146,8 +146,8 @@ func (h *HttpResolver) get() []string {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		rlog.Error("name server read http response failed", map[string]interface{}{
-			"NameServerDomain": h.domain,
-			"err":              err,
+			"NameServerDomain":       h.domain,
+			rlog.LogKeyUnderlayError: err,
 		})
 		return nil
 	}
@@ -167,8 +167,8 @@ func (h *HttpResolver) saveSnapshot(body []byte) error {
 	err := ioutil.WriteFile(filePath, body, 0644)
 	if err != nil {
 		rlog.Error("name server snapshot save failed", map[string]interface{}{
-			"filePath": filePath,
-			"err":      err,
+			"filePath":               filePath,
+			rlog.LogKeyUnderlayError: err,
 		})
 		return err
 	}
@@ -206,7 +206,7 @@ func (h *HttpResolver) getSnapshotFilePath(instanceName string) string {
 		homeDir = usr.HomeDir
 	} else {
 		rlog.Error("name server domain, can't get user home directory", map[string]interface{}{
-			"err": err,
+			rlog.LogKeyUnderlayError: err,
 		})
 	}
 	storePath := path.Join(homeDir, "/logs/rocketmq-go/snapshot")

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -88,6 +88,7 @@ func (p *defaultProducer) Start() error {
 		if err != nil {
 			rlog.Error("the producer group has been created, specify another one", map[string]interface{}{
 				rlog.LogKeyProducerGroup: p.group,
+				rlog.LogKeyUnderlayError: err,
 			})
 			err = errors2.ErrProducerCreated
 			return


### PR DESCRIPTION
## What is the purpose of the change

- record error information necessary
- format the key of log entry 
- using err instead of err.Error()
