### PR TITLE
fix: client version mismatch

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	clientVersion        = "v2.1.0"
+	clientVersion        = "v2.1.1"
 	defaultTraceRegionID = "DefaultRegion"
 
 	// tracing message switch


### PR DESCRIPTION
The client version mismatch when using branch master<c8d06a66>
<img width="927" alt="image" src="https://user-images.githubusercontent.com/20664531/219868416-594a2f4e-9bf7-4ee8-85c0-09c953c860c5.png">
