### PR TITLE
[ISSUE #1046] fix build replay message lose body

### DIFF
--- a/consumer/message_util.go
+++ b/consumer/message_util.go
@@ -42,7 +42,7 @@ func CreateReplyMessage(requestMessage *primitive.MessageExt, body []byte) (*pri
 
 	var replayMessage primitive.Message
 
-	replayMessage.UnmarshalProperties(body)
+	replayMessage.Body = body
 	replayMessage.Topic = internal.GetReplyTopic(cluster)
 	replayMessage.WithProperty(primitive.PropertyMsgType, internal.ReplyMessageFlag)
 	replayMessage.WithProperty(primitive.PropertyCorrelationID, correlationId)


### PR DESCRIPTION
## What is the purpose of the change

CreateReplyMessage 并没有将body信息写入message而是使用UnmarshalProperties无意义 [issues https://github.com/apache/rocketmq-client-go/issues/1046]

## Brief changelog

fix build replay message lose body

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
