### PR TITLE
feat: support consumer consume tps option

### DIFF
--- a/consumer/option.go
+++ b/consumer/option.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"go.uber.org/atomic"
+
 	"github.com/apache/rocketmq-client-go/v2/hooks"
 	"github.com/apache/rocketmq-client-go/v2/internal"
 	"github.com/apache/rocketmq-client-go/v2/primitive"

--- a/consumer/option.go
+++ b/consumer/option.go
@@ -55,8 +55,8 @@ type consumerOptions struct {
 
 	// Flow control threshold on topic level, default value is -1(Unlimited)
 	//
-	// The value of {@code pullThresholdForQueue} will be overwrote and calculated based on
-	// {@code pullThresholdForTopic} if it is't unlimited
+	// The value of {@code pullThresholdForQueue} will be overwritten and calculated based on
+	// {@code pullThresholdForTopic} if it isn't unlimited
 	//
 	// For example, if the value of pullThresholdForTopic is 1000 and 10 message queues are assigned to this consumer,
 	// then pullThresholdForQueue will be set to 100
@@ -64,21 +64,24 @@ type consumerOptions struct {
 
 	// Limit the cached message size on topic level, default value is -1 MiB(Unlimited)
 	//
-	// The value of {@code pullThresholdSizeForQueue} will be overwrote and calculated based on
-	// {@code pullThresholdSizeForTopic} if it is't unlimited
+	// The value of {@code pullThresholdSizeForQueue} will be overwritten and calculated based on
+	// {@code pullThresholdSizeForTopic} if it isn't unlimited
 	//
 	// For example, if the value of pullThresholdSizeForTopic is 1000 MiB and 10 message queues are
 	// assigned to this consumer, then pullThresholdSizeForQueue will be set to 100 MiB
 	PullThresholdSizeForTopic int
 
 	// Message pull Interval
-	PullInterval time.Duration
+	PullInterval atomic.Duration
+
+	// Message consumer tps
+	ConsumeTPS atomic.Int32
 
 	// Batch consumption size
 	ConsumeMessageBatchMaxSize int
 
 	// Batch pull size
-	PullBatchSize int32
+	PullBatchSize atomic.Int32
 
 	// Whether update subscription relationship when every pull
 	PostSubscriptionWhenPull bool
@@ -283,7 +286,7 @@ func WithStrategy(strategy AllocateStrategy) Option {
 
 func WithPullBatchSize(batchSize int32) Option {
 	return func(options *consumerOptions) {
-		options.PullBatchSize = batchSize
+		options.PullBatchSize.Store(batchSize)
 	}
 }
 
@@ -307,7 +310,14 @@ func WithSuspendCurrentQueueTimeMillis(suspendT time.Duration) Option {
 
 func WithPullInterval(interval time.Duration) Option {
 	return func(options *consumerOptions) {
-		options.PullInterval = interval
+		options.PullInterval.Store(interval)
+	}
+}
+
+// WithConsumeTPS set single-machine consumption tps
+func WithConsumeTPS(tps int32) Option {
+	return func(options *consumerOptions) {
+		options.ConsumeTPS.Store(tps)
 	}
 }
 

--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -700,7 +700,7 @@ func (pc *defaultPullConsumer) pullMessage(request *PullRequest) {
 			time.Sleep(sleepTime)
 		}
 		// reset time
-		sleepTime = pc.option.PullInterval
+		sleepTime = pc.option.PullInterval.Load()
 		pq.lastPullTime.Store(time.Now())
 		err := pc.makeSureStateOK()
 		if err != nil {
@@ -736,7 +736,7 @@ func (pc *defaultPullConsumer) pullMessage(request *PullRequest) {
 			Topic:                request.mq.Topic,
 			QueueId:              int32(request.mq.QueueId),
 			QueueOffset:          request.nextOffset,
-			MaxMsgNums:           pc.option.PullBatchSize,
+			MaxMsgNums:           pc.option.PullBatchSize.Load(),
 			SysFlag:              sysFlag,
 			CommitOffset:         0,
 			SubExpression:        sd.SubString,

--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -596,7 +596,7 @@ func (pc *pushConsumer) validate() error {
 		}
 	}
 
-	if pc.option.PullInterval < 0 || pc.option.PullInterval > 65535*time.Millisecond {
+	if interval := pc.option.PullInterval.Load(); interval < 0 || interval > 65535*time.Millisecond {
 		return errors.New("option.PullInterval out of range [0, 65535]")
 	}
 
@@ -608,9 +608,9 @@ func (pc *pushConsumer) validate() error {
 		}
 	}
 
-	if pc.option.PullBatchSize < 1 || pc.option.PullBatchSize > 1024 {
-		if pc.option.PullBatchSize == 0 {
-			pc.option.PullBatchSize = 32
+	if pullBatchSize := pc.option.PullBatchSize.Load(); pullBatchSize < 1 || pullBatchSize > 1024 {
+		if pullBatchSize == 0 {
+			pc.option.PullBatchSize.Store(32)
 		} else {
 			return errors.New("option.PullBatchSize out of range [1, 1024]")
 		}
@@ -674,7 +674,7 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 			time.Sleep(sleepTime)
 		}
 		// reset time
-		sleepTime = pc.option.PullInterval
+		sleepTime = pc.option.PullInterval.Load()
 		pq.lastPullTime.Store(time.Now())
 		err := pc.makeSureStateOK()
 		if err != nil {
@@ -813,7 +813,7 @@ func (pc *pushConsumer) pullMessage(request *PullRequest) {
 			Topic:                request.mq.Topic,
 			QueueId:              int32(request.mq.QueueId),
 			QueueOffset:          request.nextOffset,
-			MaxMsgNums:           pc.option.PullBatchSize,
+			MaxMsgNums:           pc.option.PullBatchSize.Load(),
 			SysFlag:              sysFlag,
 			CommitOffset:         commitOffsetValue,
 			SubExpression:        subExpression,


### PR DESCRIPTION
At present, there are two ways to control the rate of consumption, one is to limit consumer goroutine number (or the increased load on the machine slowed it down), and the other is to set `pullInterval` and `batchSize`.

Because the second way is easier to estimate the maximum consumption tps, we generally use the second one.
but the inconvenient thing is that when the backlog is relatively large, if we want to accelerate the consumption speed, we have to change the code and publish, the expansion of the machine can not solve the problem. 

The java version can dynamically set the pull interval, but the go version cannot be dynamically modified. For convenience, the maximum consumption tps setting of a single machine is supported.

```
Principle of flow control: 
pull TPS = 1000ms/PullInterval * BatchSize * len(allocateResult)
```
Based on the number of allocated queues and the number of pulls in each batch, dynamic calculation is implemented to realize how often to pull, in order to control the consumption TPS of a single machine, and achieve consumption speed control more conveniently.
This function is not enabled by default. If not enabled, it will be compatible with the original version.

目前，有两种控制消耗速度的方法，一种是限制Go消费协程的数量(或者压力使机器负载上升最终达到最大消费能力，被压式)，另一种是设置 `pullInterval`  和  `batchSize`。

由于第二种方法更容易估计最大消耗tps，所以我们通常使用第二种方法。但不方便的是，当积压量比较大的时候，如果我们想要加速的消费能力，就得改代码，扩容机器解决不了问题。

Java版本支持动态设置 pullInterval 但目前 Go版本并没有暴露相应的方式来动态修改此选项。因此，这里增加一种设置单机TPS能力，这会使使用起来更方便。

原理是根据分配的队列数，和每批次拉取数量，来实现动态计算多久拉取一次，以实现控制单机消费TPS，可以更方便地实现消费控速。  这个功能默认是不开启的，不启用的话和原来是兼容的。
