### PR TITLE
[ISSUE #1102] fix send async err occur panic: runtime error: invalid …

### DIFF
--- a/producer/producer.go
+++ b/producer/producer.go
@@ -405,6 +405,7 @@ func (p *defaultProducer) sendAsync(ctx context.Context, msg *primitive.Message,
 		cancel()
 		if err != nil {
 			h(ctx, nil, err)
+			return
 		}
 
 		resp := primitive.NewSendResult()


### PR DESCRIPTION
miss return when send async err, so occur panic: runtime error: invalid memory address or nil pointer #1102 