### PR TITLE
[ISSUE #1112] feat: optimize producer send async

### DIFF
--- a/producer/producer.go
+++ b/producer/producer.go
@@ -329,7 +329,7 @@ func (p *defaultProducer) sendSync(ctx context.Context, msg *primitive.Message, 
 		if mq != nil {
 			lastBrokerName = mq.BrokerName
 		}
-		mq := p.selectMessageQueue(msg, lastBrokerName)
+		mq = p.selectMessageQueue(msg, lastBrokerName)
 		if mq == nil {
 			err = fmt.Errorf("the topic=%s route info not found", msg.Topic)
 			continue


### PR DESCRIPTION
## What is the purpose of the change

https://github.com/apache/rocketmq-client-go/issues/1112 optimize producer send async, without block (connect and sendRequest)

## Comparison of the time spent sending messages
old version
![image](https://github.com/apache/rocketmq-client-go/assets/5609468/d9290a90-2309-4c03-aed4-6a4506936a7f)

new version
![image](https://github.com/apache/rocketmq-client-go/assets/5609468/474231ff-3478-4d4e-83a1-f53825c01675)



## Example to Test
```
package main

import (
	"context"
	"fmt"
	"time"

	"github.com/apache/rocketmq-client-go/v2"
	"github.com/apache/rocketmq-client-go/v2/primitive"
	"github.com/apache/rocketmq-client-go/v2/producer"
)

var defaultProducer = getProducer()

func getProducer() rocketmq.Producer {
	p, err := rocketmq.NewProducer(
		producer.WithSendMsgTimeout(time.Second*3),
		producer.WithRetry(2),
	)
	if err != nil {
		panic(err)
	}
	err = p.Start()
	if err != nil {
		panic(err)
	}
	return p
}

func sendMsg(topic string, body []byte) error {
	msg := primitive.NewMessage(topic, body)
	ctx := context.Background()
	startTime := time.Now()
	err := defaultProducer.SendAsync(ctx, func(ctx context.Context, result *primitive.SendResult, err error) {
		if err != nil {
			fmt.Println(err)
			return
		}
		fmt.Println(result.MsgID)
	}, msg)
	fmt.Println("t: ", time.Since(startTime))
	return err
}

func main() {
	for i := 0; i < 20; i++ {
		sendMsg("your-topic-here", []byte("test-body1"))
	}
	time.Sleep(time.Second * 10)
	return
}

```
