### PR TITLE
fix: ignore name server connection read timeout log

### DIFF
--- a/internal/remote/remote_client.go
+++ b/internal/remote/remote_client.go
@@ -174,6 +174,10 @@ func (c *remotingClient) receiveResponse(r *tcpConnWrapper) {
 	header := primitive.GetHeader()
 	defer primitive.BackHeader(header)
 	for {
+		// ignore timeout
+		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+			err = nil
+		}
 		if err != nil {
 			// conn has been closed actively
 			if r.isClosed(err) {

--- a/internal/remote/remote_client.go
+++ b/internal/remote/remote_client.go
@@ -180,11 +180,11 @@ func (c *remotingClient) receiveResponse(r *tcpConnWrapper) {
 				return
 			}
 			// ignore name server connection read timeout
-			var isTimeout bool
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-				isTimeout = true
-			}
-			if err != io.EOF && !isTimeout {
+				rlog.Debug("conn error, close connection", map[string]interface{}{
+					rlog.LogKeyUnderlayError: err,
+				})
+			} else if err != io.EOF {
 				rlog.Error("conn error, close connection", map[string]interface{}{
 					rlog.LogKeyUnderlayError: err,
 				})


### PR DESCRIPTION
## What is the purpose of the change

https://github.com/apache/rocketmq-client-go/blob/3f9c59fdf5d4cef0994939228f40886517d42d6f/internal/remote/remote_client.go#L177-L195

the error logs 

> 2023-12-05T10:33:03+08:00 ERROR remote/remote_client.go:183 github.com/apache/rocketmq-client-go/v2/internal/remote.(*remotingClient).receiveResponse conn error, close connection {"underlayError": "read tcp 192.7.128.158:43358->192.183.1.196:9876: i/o timeout"}

when get route info from name server  timeout, just ignore the error log

## Brief changelog

ignore conn read timeout log