### PR TITLE
add new kind of NsResolver: dnsResolver

### DIFF
--- a/primitive/nsresolver.go
+++ b/primitive/nsresolver.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"os"
 	"os/user"
@@ -82,6 +83,44 @@ func (p *passthroughResolver) Resolve() []string {
 
 func (p *passthroughResolver) Description() string {
 	return fmt.Sprintf("passthrough resolver of %v", p.addr)
+}
+
+type dnsResolver struct {
+	addrs    []string
+	failback NsResolver
+}
+
+func NewDNSResolver(addrs []string) *dnsResolver {
+	return &dnsResolver{
+		addrs:    addrs,
+		failback: NewEnvResolver(),
+	}
+}
+
+func (p *dnsResolver) Resolve() []string {
+	finalAddrs := make([]string, 0, len(p.addrs))
+	for _, addr := range p.addrs {
+		// ns1.example.com:9876
+		domainPort := strings.Split(addr, ":")
+		if len(domainPort) != 2 {
+			continue
+		}
+		ns, err := net.LookupHost(domainPort[0])
+		if err != nil {
+			continue
+		}
+		for _, host := range ns {
+			finalAddrs = append(finalAddrs, host+":"+domainPort[1])
+		}
+	}
+	if len(finalAddrs) > 0 {
+		return finalAddrs
+	}
+	return p.failback.Resolve()
+}
+
+func (p *dnsResolver) Description() string {
+	return fmt.Sprintf("dns resolver of %v", p.addrs)
 }
 
 const (

--- a/primitive/nsresolver_test.go
+++ b/primitive/nsresolver_test.go
@@ -172,3 +172,15 @@ func TestHttpResolverWithSnapshotFileOnce(t *testing.T) {
 		So(Diff(addrs1, srvs), ShouldBeFalse)
 	})
 }
+
+func TestDNSResolver(t *testing.T) {
+	Convey("Test UpdateNameServerAddress Use DNS", t, func() {
+		srvs := []string{
+			"127.0.0.1:9876",
+		}
+
+		resolver := NewDNSResolver([]string{"localhost:9876"})
+		addrs := resolver.Resolve()
+		So(Diff(srvs, addrs), ShouldBeTrue)
+	})
+}


### PR DESCRIPTION
## What is the purpose of the change

fix [#1122](https://github.com/apache/rocketmq-client-go/issues/1122)

## Brief changelog

add new kind of NsResolver: dnsResolver to support nameserver in the form of domain name.

like this
```
p, err := rocketmq.NewProducer(
	producer.WithNsResolver(primitive.NewDNSResolver([]string{"ns1.example.com:9876"})),
	producer.WithRetry(2),
)
```

## Verifying this change
I have add unit test In primitive/nsresolver_test.go.



