### PR TITLE
[ISSUE #1124] fix: panic in SendResult.String

### DIFF
--- a/primitive/result.go
+++ b/primitive/result.go
@@ -58,8 +58,12 @@ func NewSendResult() *SendResult {
 
 // SendResult send message result to string(detail result)
 func (result *SendResult) String() string {
+	mq := "nil"
+	if result.MessageQueue != nil {
+		mq = result.MessageQueue.String()
+	}
 	return fmt.Sprintf("SendResult [sendStatus=%d, msgIds=%s, offsetMsgId=%s, queueOffset=%d, messageQueue=%s]",
-		result.Status, result.MsgID, result.OffsetMsgID, result.QueueOffset, result.MessageQueue.String())
+		result.Status, result.MsgID, result.OffsetMsgID, result.QueueOffset, mq)
 }
 
 // TransactionSendResult RocketMQ send result


### PR DESCRIPTION
## What is the purpose of the change

The String() method in SendResult struct can cause a panic when MessageQueue field is nil. This is because String() method tries to access MessageQueue.String() without checking if MessageQueue is nil.

## Brief changelog
This PR adds a nil check for MessageQueue before calling its String() method. If MessageQueue is nil, it uses the string "nil" to represent it.

This solution prevents the panic and makes SendResult.String() method more robust.

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
