### PR TITLE
[ISSUE #1136]should also set Credentials for nameserver in admin and pull consumer

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -102,6 +102,9 @@ func NewAdmin(opts ...AdminOption) (*admin, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !defaultOpts.Credentials.IsEmpty() {
+		namesrv.SetCredentials(defaultOpts.Credentials)
+	}
 
 	cli := internal.GetOrNewRocketMQClient(defaultOpts.ClientOptions, nil)
 	if cli == nil {

--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -92,6 +92,9 @@ func NewPullConsumer(options ...Option) (*defaultPullConsumer, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "new Namesrv failed.")
 	}
+	if !defaultOpts.Credentials.IsEmpty() {
+		srvs.SetCredentials(defaultOpts.Credentials)
+	}
 
 	defaultOpts.Namesrv = srvs
 	dc := &defaultConsumer{


### PR DESCRIPTION
## What is the purpose of the change

Like the producer and push consumer, should also set Credentials for nameserver in admin and pull consumer. 
fix #1136 

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
