### PR TITLE
feat: batchSend messages return result has msgIds and offsetMsgId

### DIFF
--- a/internal/client.go
+++ b/internal/client.go
@@ -741,8 +741,12 @@ func (c *rmqClient) ProcessSendResponse(brokerName string, cmd *remote.RemotingC
 	}
 
 	msgIDs := make([]string, 0)
-	for i := 0; i < len(msgs); i++ {
-		msgIDs = append(msgIDs, msgs[i].GetProperty(primitive.PropertyUniqueClientMessageIdKeyIndex))
+	if msgs[0].Batch {
+		for i := range msgs[0].List {
+			msgIDs = append(msgIDs, msgs[0].List[i].GetProperty(primitive.PropertyUniqueClientMessageIdKeyIndex))
+		}
+	} else {
+		msgIDs = append(msgIDs, msgs[0].GetProperty(primitive.PropertyUniqueClientMessageIdKeyIndex))
 	}
 	uniqueMsgId := strings.Join(msgIDs, ",")
 

--- a/primitive/message.go
+++ b/primitive/message.go
@@ -69,6 +69,7 @@ const (
 )
 
 type Message struct {
+	List           []*Message
 	Topic          string
 	Body           []byte
 	CompressedBody []byte

--- a/producer/producer.go
+++ b/producer/producer.go
@@ -144,12 +144,14 @@ func (p *defaultProducer) encodeBatch(msgs ...*primitive.Message) *primitive.Mes
 	batch.Queue = msgs[0].Queue
 	batch.Body = MarshalMessageBatch(msgs...)
 	batch.Batch = true
+	batch.List = msgs
 	return batch
 }
 
 func MarshalMessageBatch(msgs ...*primitive.Message) []byte {
 	buffer := bytes.NewBufferString("")
 	for _, msg := range msgs {
+		msg.WithProperty(primitive.PropertyUniqueClientMessageIdKeyIndex, primitive.CreateUniqID())
 		data := msg.Marshal()
 		buffer.Write(data)
 	}


### PR DESCRIPTION
## What is the purpose of the change

batchSend messages return result has msgIds and offsetMsgId

## Brief changelog

XX

## Verifying this change

batchSend result before
![企业微信截图_0e260a7f-cf10-4402-a16b-98e98421415c](https://github.com/user-attachments/assets/4bebda60-c17d-4ea0-9b91-65889b255371)
batchSend result now
![企业微信截图_0e260a7f-cf10-4402-a16b-98e98421415c](https://github.com/user-attachments/assets/0434fe30-6b8c-40de-89e9-07e6c4eb902a)

