### PR TITLE
[ISSUE 1152] add feature, support message delay any time

### DIFF
--- a/examples/producer/delayms/main.go
+++ b/examples/producer/delayms/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/apache/rocketmq-client-go/v2"
+	"github.com/apache/rocketmq-client-go/v2/primitive"
+	"github.com/apache/rocketmq-client-go/v2/producer"
+)
+
+var (
+	topic         string
+	endpoint      string
+	accessKey     string
+	secretKey     string
+	messageCount  int
+	delayInterval int
+)
+
+func init() {
+	flag.StringVar(&topic, "topic", "benchmark-queue-1", "topic name")
+	flag.StringVar(&endpoint, "endpoint", "127.0.0.1:9876", "endpoint")
+	flag.StringVar(&accessKey, "access_key", "******", "access key")
+	flag.StringVar(&secretKey, "secret_key", "******", "secret key")
+	flag.IntVar(&messageCount, "count", 10, "message count")
+	flag.IntVar(&delayInterval, "delay", 0, "delay interval unit: sec")
+}
+
+// Package main implements a simple producer to send message.
+func main() {
+	flag.Parse()
+
+	p, err := rocketmq.NewProducer(
+		producer.WithNsResolver(primitive.NewPassthroughResolver([]string{endpoint})),
+		producer.WithRetry(2),
+	)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	err = p.Start()
+	if err != nil {
+		fmt.Printf("start producer error: %s", err.Error())
+		os.Exit(1)
+	}
+
+	for i := 0; i < messageCount; i++ {
+		msg := &primitive.Message{
+			Topic: topic,
+			Body: []byte("Hello RocketMQ Go Client! " + strconv.Itoa(i) +
+				" timestamp:" + strconv.FormatInt(time.Now().Unix(), 10)),
+		}
+		if delayInterval > 0 {
+			msg.WithDelayTimestamp(time.Now().Add(time.Duration(delayInterval) * time.Second))
+		}
+		res, err := p.SendSync(context.Background(), msg)
+
+		if err != nil {
+			fmt.Printf("index: %v, send message error: %s\n", i+1, err)
+			break
+		} else {
+			fmt.Printf("index: %v, send message success: result=%s\n", i+1, res.String())
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	err = p.Shutdown()
+	if err != nil {
+		fmt.Printf("shutdown producer error: %s", err.Error())
+	}
+}

--- a/primitive/message.go
+++ b/primitive/message.go
@@ -38,6 +38,7 @@ const (
 	PropertyWaitStoreMsgOk                 = "WAIT"
 	PropertyDelayTimeLevel                 = "DELAY"
 	PropertyRetryTopic                     = "RETRY_TOPIC"
+	PropertyTimerDeliverMS                 = "TIMER_DELIVER_MS"
 	PropertyRealTopic                      = "REAL_TOPIC"
 	PropertyRealQueueId                    = "REAL_QID"
 	PropertyTransactionPrepared            = "TRAN_MSG"
@@ -176,6 +177,11 @@ func (m *Message) WithDelayTimeLevel(level int) *Message {
 	return m
 }
 
+func (m *Message) WithDelayTimestamp(deliveryTimestamp time.Time) *Message {
+	timeMs := deliveryTimestamp.Unix()*1000 + int64(deliveryTimestamp.Nanosecond()/1000000)
+	m.WithProperty(PropertyTimerDeliverMS, strconv.FormatInt(timeMs, 10))
+	return m
+}
 func (m *Message) WithTag(tags string) *Message {
 	m.WithProperty(PropertyTags, tags)
 	return m


### PR DESCRIPTION
[ISSUE 1152]
## What is the purpose of the change

support send delay message at any time 

## Brief changelog


## Verifying this change
I verify this feature use the server rocketmq v5.2.0
execute command
cd examples/producer/delayms/
build -o main main.go
// delay one and a half day，  129600s
./main  --topic=benchmark-queue-1 --endpoint=10.3.*.*:9876  --count=10  --delay=129600

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
