### PR TITLE
fix: withRecover cannot recover panic

### DIFF
--- a/primitive/base.go
+++ b/primitive/base.go
@@ -85,14 +85,22 @@ func verifyIP(ip string) error {
 	return nil
 }
 
-var PanicHandler func(interface{})
+type PanicHandler func(interface{})
 
-func WithRecover(fn func()) {
+func DefaultPanicHandler(any) {
+	return
+}
+
+func WithRecover(fn func(), handlers ...PanicHandler) {
 	defer func() {
-		handler := PanicHandler
-		if handler != nil {
-			if err := recover(); err != nil {
-				handler(err)
+		if len(handlers) == 0 {
+			handlers = append(handlers, DefaultPanicHandler)
+		}
+		for _, handler := range handlers {
+			if handler != nil {
+				if err := recover(); err != nil {
+					handler(err)
+				}
 			}
 		}
 	}()

--- a/primitive/base.go
+++ b/primitive/base.go
@@ -87,7 +87,7 @@ func verifyIP(ip string) error {
 
 type PanicHandler func(interface{})
 
-func DefaultPanicHandler(any) {
+func DefaultPanicHandler(interface{}) {
 	return
 }
 


### PR DESCRIPTION
## What is the purpose of the change


Fix the problem that the withRecover method cannot capture panic normally

## Brief changelog

* PanicHandler is converted from a variable to a type.
* Define a default DefaultPanicHandler method.
* WithRecover defines a variadic parameter handlers, and if none are passed, it adds DefaultPanicHandler to the handlers. 

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [x] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
