### PR TITLE
fix: fix slice init length

### DIFF
--- a/internal/trace.go
+++ b/internal/trace.go
@@ -419,7 +419,7 @@ func (td *traceDispatcher) batchCommit(ctxs []TraceContext) {
 type Keyset map[string]struct{}
 
 func (ks Keyset) slice() []string {
-	slice := make([]string, len(ks))
+	slice := make([]string, 0, len(ks))
 	for k, _ := range ks {
 		slice = append(slice, k)
 	}


### PR DESCRIPTION
## What is the purpose of the change

The intention here should be to initialize a slice with a capacity of  `len(ks)`  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
