### PR TITLE
make default panic handler could be customized

### DIFF
--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -1111,6 +1111,9 @@ func (pc *pushConsumer) consumeMessageConcurrently(pq *processQueue, mq *primiti
 		go primitive.WithRecover(func() {
 			defer func() {
 				if err := recover(); err != nil {
+					if primitive.DefaultPanicHandler != nil {
+						primitive.DefaultPanicHandler(err)
+					}
 					rlog.Error("consumeMessageConcurrently panic", map[string]interface{}{
 						rlog.LogKeyUnderlayError: err,
 						rlog.LogKeyStack:         utils.GetStackAsString(false),

--- a/primitive/base.go
+++ b/primitive/base.go
@@ -87,14 +87,19 @@ func verifyIP(ip string) error {
 
 type PanicHandler func(interface{})
 
-func DefaultPanicHandler(interface{}) {
-	return
-}
+//	primitive.DefaultPanicHandler = func(i interface{}) {
+//		sentry.CaptureMessage(fmt.Sprintf("%+v", i), nil)
+//	}
+var DefaultPanicHandler PanicHandler
 
 func WithRecover(fn func(), handlers ...PanicHandler) {
 	defer func() {
 		if len(handlers) == 0 {
-			handlers = append(handlers, DefaultPanicHandler)
+			if DefaultPanicHandler != nil {
+				handlers = append(handlers, DefaultPanicHandler)
+			} else {
+				handlers = append(handlers, func(interface{}) {})
+			}
 		}
 		for _, handler := range handlers {
 			if handler != nil {

--- a/primitive/base_test.go
+++ b/primitive/base_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package primitive
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -73,4 +74,24 @@ func TestBase(t *testing.T) {
 	a = []string{"b", "a"}
 	b = []string{"a", "c"}
 	assert.True(t, Diff(a, b))
+}
+
+func TestWithRecover(t *testing.T) {
+	ass := assert.New(t)
+
+	DefaultPanicHandler = nil
+	ass.NotPanics(func() {
+		WithRecover(func() {
+			panic("test")
+		})
+	})
+
+	DefaultPanicHandler = func(i interface{}) {
+		fmt.Println("panic test")
+	}
+	ass.NotPanics(func() {
+		WithRecover(func() {
+			panic("test")
+		})
+	})
 }


### PR DESCRIPTION
## What is the purpose of the change
https://github.com/apache/rocketmq-client-go/pull/1074#issuecomment-1837775085

in old version, we could do this
```
primitive.PanicHandler = func(i interface{}) {
     msentry.CaptureMessage(fmt.Sprintf("%+v", i), nil)
}
```
but in latest version, default panic handler could not be customized.


when push consume panic, default panic handler should be called (we log and monitor the panic in default panic handler)
![image](https://github.com/user-attachments/assets/29ee167e-0c19-49f2-b737-f9e6c162506a)
