### PR TITLE
fix(utils): Fix file backup logic in WriteToFile and enhance test coverage

### DIFF
--- a/internal/utils/files.go
+++ b/internal/utils/files.go
@@ -73,7 +73,7 @@ func WriteToFile(path string, data []byte) error {
 	prevContent, err := FileReadAll(path)
 	if err == nil {
 		bakFile, err := os.Create(path + ".bak")
-		if err != nil {
+		if err == nil {
 			_, err = bakFile.Write(prevContent)
 		}
 		if err != nil {

--- a/internal/utils/files_test.go
+++ b/internal/utils/files_test.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileReadAll_Success(t *testing.T) {
+	content := []byte("test content")
+	tmpfile, err := os.CreateTemp("", "example")
+	assert.Nil(t, err)
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write(content)
+	assert.Nil(t, err)
+	assert.Nil(t, tmpfile.Close())
+
+	data, err := FileReadAll(tmpfile.Name())
+
+	assert.Nil(t, err)
+	assert.Equal(t, content, data)
+}
+
+func TestFileReadAll_FileNotExist(t *testing.T) {
+	data, err := FileReadAll("nonexistent_file")
+
+	assert.NotNil(t, err)
+	assert.Nil(t, data)
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestFileReadAll_OpenError(t *testing.T) {
+	// create a directory which can't be opened as a file
+	tmpDir, err := os.MkdirTemp("", "testdir")
+	assert.Nil(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	data, err := FileReadAll(tmpDir)
+
+	assert.NotNil(t, err)
+	assert.Nil(t, data)
+}
+
+func TestEnsureDir_Success(t *testing.T) {
+	dir := "tmpdir"
+
+	err := os.Mkdir(dir, 0755)
+	defer os.Remove(dir)
+	assert.Nil(t, err)
+
+	err = ensureDir(dir)
+	assert.Nil(t, err)
+}
+
+func TestEnsureDir_CreateIfNotExist(t *testing.T) {
+	dir := "tmpdir"
+
+	err := ensureDir(dir)
+	defer os.Remove(dir)
+
+	assert.Nil(t, err)
+	info, err := os.Stat(dir)
+	assert.Nil(t, err)
+	assert.True(t, info.IsDir())
+}
+
+func TestEnsureDir_Fail(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "testfile")
+	assert.Nil(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	err = ensureDir(tmpFile.Name())
+	assert.NotNil(t, err)
+}
+
+func TestWriteToFile_FileExist(t *testing.T) {
+	var (
+		existFileName string
+		oldContent    = []byte("old content")
+		newContent    = []byte("new content")
+	)
+	// prepare a exist file with data
+	existFile, _ := os.CreateTemp("", "TestWriteToFile_FileExist")
+	existFileName = existFile.Name()
+
+	existFile.Write(oldContent)
+	existFile.Close()
+
+	err := WriteToFile(existFileName, newContent)
+	assert.Nil(t, err)
+
+	check := func(t *testing.T, path string, expectedData []byte) {
+		f, err := os.Open(path)
+		defer os.Remove(path)
+
+		assert.Nil(t, err)
+		data, err := io.ReadAll(f)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedData, data)
+	}
+
+	check(t, existFileName, newContent)
+	check(t, existFileName+".bak", oldContent)
+}

--- a/internal/utils/set_test.go
+++ b/internal/utils/set_test.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSet_NormalUsage(t *testing.T) {
+	set := NewSet()
+	set.AddKV("name", "xiaoming")
+	set.AddKV("age", "18")
+	set.Add(StringUnique("hello"))
+
+	name, ok := set.Contains("name")
+	assert.True(t, ok)
+	assert.Equal(t, "xiaoming", name.UniqueID())
+
+	_, ok = set.Contains("gender")
+	assert.False(t, ok)
+
+	assert.Equal(t, 3, set.Len())
+}
+
+func TestSet_MarshalJSON(t *testing.T) {
+	st := NewSet()
+
+	st.AddKV("name", "xiaoming")
+	st.AddKV("age", "18")
+	st.Add(StringUnique("hello"))
+
+	data, err := json.Marshal(&st)
+	assert.Nil(t, err)
+	t.Log(string(data))
+}


### PR DESCRIPTION
## What is the purpose of the change

In the internal/utils/files.go package, the WriteToFile function failed to properly backup existing file contents when overwriting files. Specifically:

When writing to an existing path (e.g., aaa/exist.txt), the function only create a backup file (aaa/exist.txt.bak) before overwriting, but write nothing, leading to potential data loss.

Existing test cases lacked coverage for backup logic and related file utility functions.

## Brief changelog

-  fix `internal/utils/files.go:WriteToFile`
- add `internal/utils/files_test.go`
- add `internal/utils/set_test.go`

## Verifying this change

see test file

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
