### PR TITLE
fix trace messge batch more than batchSize

### DIFF
--- a/internal/trace.go
+++ b/internal/trace.go
@@ -103,7 +103,7 @@ func (ctx *TraceContext) marshal2Bean() *TraceTransferBean {
 		} else {
 			buffer.WriteString(bean.Topic)
 		}
-		//buffer.WriteString(bean.Topic)
+		// buffer.WriteString(bean.Topic)
 		buffer.WriteRune(contentSplitter)
 		buffer.WriteString(bean.MsgId)
 		buffer.WriteRune(contentSplitter)
@@ -358,9 +358,9 @@ func (td *traceDispatcher) process(maxWaitTime int64) {
 		case <-td.ticker.C:
 			delta := time.Since(lastput).Nanoseconds()
 			if delta > maxWaitTime {
-				count++
 				lastput = time.Now()
 				if len(batch) > 0 {
+					count = 0
 					batchSend := batch
 					go primitive.WithRecover(func() {
 						td.batchCommit(batchSend)


### PR DESCRIPTION
## What is the purpose of the change

batchSize == 100
when count is 99, and run this case [case <-td.ticker.C:], now count is 100 
then run this case: [case ctx := <-td.input: count++], now count is 101

this condition will never satisfy [if count == batchSize] and count will never go back to zero. 

## Brief changelog

XX

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
