### PR TITLE
feat: fix push consumer pause data race

### DIFF
--- a/consumer/push_consumer.go
+++ b/consumer/push_consumer.go
@@ -98,6 +98,7 @@ func NewPushConsumer(opts ...Option) (*pushConsumer, error) {
 		consumerGroup:  defaultOpts.GroupName,
 		cType:          _PushConsume,
 		state:          atomic.NewInt32(int32(internal.StateCreateJust)),
+		pause:          atomic.NewBool(false),
 		prCh:           make(chan PullRequest, 4),
 		model:          defaultOpts.ConsumerModel,
 		consumeOrderly: defaultOpts.ConsumeOrderly,


### PR DESCRIPTION
## What is the purpose of the change
fix pushConsumer.pause data race, when Suspend or Resume write pause, but doBalance read pause in the background.

