### PR TITLE
unlock unused queue when orderly consumer rebalance

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -436,14 +436,6 @@ func (dc *defaultConsumer) doBalance() {
 				dc.option.PullInterval.Store(time.Duration(float64(time.Second) / pullTimesPerSecond))
 			}
 
-			oldMqSet := make([]primitive.MessageQueue, 0)
-			if dc.consumeOrderly {
-				dc.processQueueTable.Range(func(key, value interface{}) bool {
-					oldMqSet = append(oldMqSet, key.(primitive.MessageQueue))
-					return true
-				})
-			}
-
 			changed := dc.updateProcessQueueTable(topic, allocateResult)
 			if changed {
 				dc.mqChanged(topic, mqAll, allocateResult)
@@ -456,21 +448,6 @@ func (dc *defaultConsumer) doBalance() {
 					"rebalanceResultSize":    len(allocateResult),
 					"rebalanceResultSet":     allocateResult,
 				})
-			}
-
-			if dc.consumeOrderly {
-				for _, mq := range oldMqSet {
-					match := false
-					for _, newMq := range allocateResult {
-						if mq.String() == newMq.String() {
-							match = true
-							break
-						}
-					}
-					if !match {
-						dc.unlock(&mq, true)
-					}
-				}
 			}			
 		}
 		return true
@@ -732,10 +709,12 @@ func (dc *defaultConsumer) updateProcessQueueTable(topic string, mqs []*primitiv
 		mq := key.(primitive.MessageQueue)
 		pq := value.(*processQueue)
 		if mq.Topic == topic {
+			unlockMqs := make([]*primitive.MessageQueue, 0, 1)
 			if !mqSet[mq] {
 				pq.WithDropped(true)
 				if dc.removeUnnecessaryMessageQueue(&mq, pq) {
 					dc.processQueueTable.Delete(key)
+					unlockMqs = append(unlockMqs, &mq)
 					changed = true
 					rlog.Info("remove unnecessary mq when updateProcessQueueTable", map[string]interface{}{
 						rlog.LogKeyConsumerGroup: dc.consumerGroup,
@@ -746,12 +725,29 @@ func (dc *defaultConsumer) updateProcessQueueTable(topic string, mqs []*primitiv
 				pq.WithDropped(true)
 				if dc.removeUnnecessaryMessageQueue(&mq, pq) {
 					dc.processQueueTable.Delete(key)
+					unlockMqs = append(unlockMqs, &mq)
 					changed = true
 					rlog.Warning("remove unnecessary mq because pull was expired, prepare to fix it", map[string]interface{}{
 						rlog.LogKeyConsumerGroup: dc.consumerGroup,
 						rlog.LogKeyMessageQueue:  mq.String(),
 					})
 				}
+			}
+
+			if dc.consumeOrderly && len(unlockMqs) > 0 {
+				// 释放掉不再订阅的mq的锁，不再订阅的mq已经在上面被删除了
+				go func() {
+					brokerResult := dc.client.GetNameSrv().FindBrokerAddressInSubscribe(mq.BrokerName, internal.MasterId, true)
+
+					if brokerResult != nil {
+						body := &lockBatchRequestBody{
+							ConsumerGroup: dc.consumerGroup,
+							ClientId:      dc.client.ClientID(),
+							MQs:           unlockMqs,
+						}
+						dc.doUnlock(brokerResult.BrokerAddr, body, false)
+					}
+				}()
 			}
 		}
 		return true


### PR DESCRIPTION
What is the purpose of the change
unlock unused queue when orderly consumer rebalance

Brief changelog
当订阅关系发生变化时，及时释放不在订阅的queue的锁以便新的消费者能够立马订阅，不用等待1分钟后锁过期再订阅。

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
