### PR TITLE
feat: Add pause initialization to default PullConsumer to prevent panic

### DIFF
--- a/consumer/pull_consumer.go
+++ b/consumer/pull_consumer.go
@@ -113,6 +113,7 @@ func NewPullConsumer(options ...Option) (*defaultPullConsumer, error) {
 		consumerGroup: utils.WrapNamespace(defaultOpts.Namespace, defaultOpts.GroupName),
 		cType:         _PullConsume,
 		state:         atomic2.NewInt32(int32(internal.StateCreateJust)),
+		pause:         atomic2.NewBool(false),
 		prCh:          make(chan PullRequest, 4),
 		model:         defaultOpts.ConsumerModel,
 		option:        defaultOpts,


### PR DESCRIPTION
## What is the purpose of the change

Add pause initialization to default PullConsumer to prevent panic

## Brief changelog

Add pause initialization to default PullConsumer to prevent panic
<img width="2224" height="206" alt="image" src="https://github.com/user-attachments/assets/1e4bd624-2280-4dd0-a951-832df0f06bcb" />



