### PR TITLE
feat: support multi unit in trace config

### DIFF
--- a/consumer/interceptor.go
+++ b/consumer/interceptor.go
@@ -20,6 +20,7 @@ package consumer
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/apache/rocketmq-client-go/v2/internal"
@@ -40,7 +41,7 @@ func WithTrace(traceCfg *primitive.TraceConfig) Option {
 }
 
 func newTraceInterceptor(dispatcher internal.TraceDispatcher) primitive.Interceptor {
-	if dispatcher != nil {
+	if dispatcher != nil && !reflect.ValueOf(dispatcher).IsNil() {
 		dispatcher.Start()
 	}
 

--- a/internal/trace.go
+++ b/internal/trace.go
@@ -275,6 +275,7 @@ func NewTraceDispatcher(traceCfg *primitive.TraceConfig) *traceDispatcher {
 
 	cliOp := DefaultClientOptions()
 	cliOp.GroupName = traceCfg.GroupName
+	cliOp.UnitName = traceCfg.UnitName
 	cliOp.NameServerAddrs = traceCfg.NamesrvAddrs
 	cliOp.InstanceName = "INNER_TRACE_CLIENT_DEFAULT"
 	cliOp.RetryTimes = 0

--- a/primitive/trace.go
+++ b/primitive/trace.go
@@ -21,6 +21,7 @@ package primitive
 type TraceConfig struct {
 	TraceTopic   string
 	GroupName    string
+	UnitName     string
 	Access       AccessChannel
 	NamesrvAddrs []string
 	Resolver     NsResolver


### PR DESCRIPTION
## What is the purpose of the change

support multi unit in trace config

## Brief changelog

When init trace intercepter for multi unit, trace client init with default unit name and instance name, cause generate same clientID for different unit server, but serverUrl resolved with different IPs, lead to client loadOrStore return nil and finally nil pointer crash.
So add UnitName param in traceConfig to allow unit name pass down.

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when a cross-module dependency exists.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
